### PR TITLE
decoding bson documents

### DIFF
--- a/lib/MongoDB.pm
+++ b/lib/MongoDB.pm
@@ -211,6 +211,12 @@ can be 1 for upsert and/or 2 for updating multiple documents.
 Creates a remove that can be used with C<MongoDB::Connection::send>.  C<$flags>
 can be 1 for removing just one matching document.
 
+=head2 read_documents($buffer)
+
+  my @documents = MongoDB::read_documents($buffer);
+
+Decodes BSON documents from the given buffer
+
 =head1 SEE ALSO
 
 MongoDB main website L<http://www.mongodb.org/>

--- a/xs/Mongo.xs
+++ b/xs/Mongo.xs
@@ -154,3 +154,17 @@ write_update(ns, criteria, obj, flags)
          XPUSHs(sv_2mortal(newSVpvn(buf.start, buf.pos-buf.start)));
          Safefree(buf.start);
 
+void
+read_documents(sv)
+         SV *sv
+    PREINIT:
+         buffer buf;
+    PPCODE:
+         buf.start = SvPV_nolen(sv);
+         buf.pos = buf.start;
+         buf.end = buf.start + SvCUR(sv);
+
+         while(buf.pos < buf.end) {
+             XPUSHs(sv_2mortal(perl_mongo_bson_to_sv(&buf)));
+         }
+


### PR DESCRIPTION
I have been working on an AnyEvent client for MongoDB. It is different from the recent AnyMongo client in that it is aiming to provide a more traditional anyevent callback API.

However I do not wish to re-implement the pack/unpack that is already in the MongoDB driver. Most is already available as functions in MongoDB:: but I needed added to perl_mongo_bson_to_sv to decode documents in a reply. The attached makes that function available as MongoDB::read_documents
