### PR TITLE
Io file uninit warning

### DIFF
--- a/lib/MongoDB/GridFS/File.pm
+++ b/lib/MongoDB/GridFS/File.pm
@@ -133,12 +133,12 @@ given, the entire file is return.
 
 sub slurp {
     my ($self,$length,$offset) = @_;
-    my $bytes;
+    my $bytes = '';
     my $fh = new IO::File \$bytes,'+>';
     my $written = $self->print($fh,$length,$offset);
 
     # some machines don't set $bytes
-    if (!$bytes) {
+    if ($written and !length($bytes)) {
        my $retval;
        read $fh, $retval, $written;
        return $retval;


### PR DESCRIPTION
This patch avoids the warning Use of uninitialized value in open at IO/File.pm
