### PR TITLE
Support for blessed hashes

### DIFF
--- a/perl_mongo.c
+++ b/perl_mongo.c
@@ -1266,6 +1266,12 @@ append_sv (buffer *buf, const char *key, SV *sv, stackette *stack, int is_insert
                 perl_mongo_serialize_bindata(buf, SvRV(sv));
               }
             }
+            else if (SvTYPE (SvRV (sv)) == SVt_PVHV ) { /* blessed hash */
+				set_type(buf, BSON_OBJECT);
+				perl_mongo_serialize_key(buf, key, is_insert);
+				/* don't add a _id to inner objs */
+				hv_to_bson (buf, sv, NO_PREP, stack, is_insert);
+			}
             else {
                 croak ("type (%s) unhandled", HvNAME(SvSTASH(SvRV(sv))));
             }


### PR DESCRIPTION
Hi,
I don't know if blocking unkown-objects ("type (Class) unknown") has a specific purpose... but I don't see why not support blessed-hashes, when they are just hashes with a blessed flag. Makes it really easy to collapse objects into a collection.
cheers,
-rodrigo
