### PR TITLE
add fields to find

### DIFF
--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -190,7 +190,7 @@ Order results.
 sub find {
     my ($self, $query, $attrs) = @_;
     # old school options - these should be set with MongoDB::Cursor methods
-    my ($limit, $skip, $sort_by) = @{ $attrs || {} }{qw/limit skip sort_by/};
+    my ($limit, $skip, $sort_by, $fields) = @{ $attrs || {} }{qw/limit skip sort_by fields/};
 
     $limit   ||= 0;
     $skip    ||= 0;
@@ -202,6 +202,7 @@ sub find {
 	_connection => $conn,
 	_ns => $ns,
 	_query => $q,
+	_fields => $fields,
 	_limit => $limit,
 	_skip => $skip
     );


### PR DESCRIPTION
Hi,

It looks like there's no way to restrict the fields returned from a query with this module.   This should take care of it.

Added fields to find() method so that we can restrict the fields we get back from mongo ( increase wire speed )
