### PR TITLE
Fix compilation for Perl 5.10

### DIFF
--- a/t/threads/basic.t
+++ b/t/threads/basic.t
@@ -61,4 +61,4 @@ END {
     }
 }
 
-done_testing;
+done_testing();

--- a/t/threads/cursor.t
+++ b/t/threads/cursor.t
@@ -107,4 +107,4 @@ END {
     }
 }
 
-done_testing;
+done_testing();

--- a/t/threads/oid.t
+++ b/t/threads/oid.t
@@ -25,4 +25,4 @@ for (@inc) {
     $prev = $_;
 }
 
-done_testing;
+done_testing();


### PR DESCRIPTION
The use of bareword 'done_testing' in strict subs leads to compilation errors

This is the output without braces:

Bareword "done_testing" not allowed while "strict subs" in use at t/threads/cursor.t line 104.
Execution of t/threads/cursor.t aborted due to compilation errors.
# Looks like your test died before it could output anything.

t/threads/cursor....dubious
    Test returned status 255 (wstat 65280, 0xff00)
FAILED--10 test scripts could be run, alas--no output ever seen
