### PR TITLE
Upcase "MONGO_SSL" in README

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ To install, run:
 
     $ perl Makefile.PL [--ssl] (if you're using mongodb with ssl)
     $ make
-    $ make test (export MONGO_SSl=1 if you're using mongodb with ssl)
+    $ make test (export MONGO_SSL=1 if you're using mongodb with ssl)
     $ sudo make install
 
 For full documentation, see the CPAN page (http://search.cpan.org/dist/MongoDB).


### PR DESCRIPTION
It was misspelled as "MONGO_SSl".
