### PR TITLE
Protect MAX_OBJ_SIZE expansion in perl_mongo.h

### DIFF
--- a/perl_mongo.h
+++ b/perl_mongo.h
@@ -113,7 +113,7 @@ typedef __int64 int64_t;
 #define BSON_MAXKEY 127
 
 #define GROW_SLOWLY 1048576
-#define MAX_OBJ_SIZE 1024*1024*4
+#define MAX_OBJ_SIZE (1024*1024*4)
 
 typedef struct {
   char *start;


### PR DESCRIPTION
This is almost certainly a no-op -- unless there's code using ~MAX_OBJ_SIZE
or (int16_t)MAX_OBJ_SIZE, for example -- which is unlikely.  More important
is the reminder for readers of the code that macros should generally expand
to parenthesized expressions.
