### PR TITLE
Use angle brackets for URL in README

### DIFF
--- a/README
+++ b/README
@@ -9,4 +9,4 @@ To install, run:
     $ make test (export MONGO_SSL=1 if you're using mongodb with ssl)
     $ sudo make install
 
-For full documentation, see the CPAN page (http://search.cpan.org/dist/MongoDB).
+For full documentation, see the CPAN page <http://search.cpan.org/dist/MongoDB>.


### PR DESCRIPTION
TextWrangler 3.1 (for Mac OS X) gets confused by a URL in parentheses -- on
Command-click, it will construe the parentheses (and following dot) as part
of the URL, and (with Firefox at least) no browser window opens.

Also, angle brackets appear to be the recommended means of delimiting URLs,
whereas parentheses aren't suggested at all.

From http://tools.ietf.org/html/rfc3986#appendix-C:

   URIs are often transmitted through formats that do not provide a
   clear context for their interpretation.  For example, there are many
   occasions when a URI is included in plain text; examples include text
   sent in email, USENET news, and on printed paper.  In such cases, it
   is important to be able to delimit the URI from the rest of the text,
   and in particular from punctuation marks that might be mistaken for
   part of the URI.

   In practice, URIs are delimited in a variety of ways, but usually
   within double-quotes "http://example.com/", angle brackets
   http://example.com/, or just by using whitespace:

```
  http://example.com/
```

[snip]

   Using <> angle brackets around each URI is especially recommended as
   a delimiting style for a reference that contains embedded whitespace.
