### PR TITLE
Write Class->new as idiomatic Class::->new

### DIFF
--- a/lib/MongoDB.pm
+++ b/lib/MongoDB.pm
@@ -37,7 +37,7 @@ MongoDB - Mongo Driver for Perl
 
     use MongoDB;
 
-    my $connection = MongoDB::Connection->new(host => 'localhost', port => 27017);
+    my $connection = MongoDB::Connection::->new(host => 'localhost', port => 27017);
     my $database   = $connection->foo;
     my $collection = $database->bar;
     my $id         = $collection->insert({ some => 'data' });
@@ -123,11 +123,11 @@ would like to learn more about authentication, see the C<authenticate> method.
 
 To connect to the database, create a new MongoDB Connection object:
 
-    $conn = MongoDB::Connection->new("host" => "localhost:27017");
+    $conn = MongoDB::Connection::->new("host" => "localhost:27017");
 
 As this is the default, we can use the equivalent shorthand:
 
-    $conn = MongoDB::Connection->new;
+    $conn = MongoDB::Connection::->new;
 
 Connecting is relatively expensive, so try not to open superfluous connections.
 

--- a/lib/MongoDB/BSON/Binary.pm
+++ b/lib/MongoDB/BSON/Binary.pm
@@ -34,12 +34,12 @@ Creates an instance of binary data with a specific subtype.
 
 For example, suppose we wanted to store a profile pic.
 
-    my $pic = MongoDB::BSON::Binary->new(data => $pic_bytes);
+    my $pic = MongoDB::BSON::Binary::->new(data => $pic_bytes);
     $collection->insert({name => "profile pic", pic => $pic});
 
 You can also, optionally, specify a subtype:
 
-    my $pic = MongoDB::BSON::Binary->new(data => $pic_bytes,
+    my $pic = MongoDB::BSON::Binary::->new(data => $pic_bytes,
         subtype => MongoDB::BSON::Binary->SUBTYPE_GENERIC);
     $collection->insert({name => "profile pic", pic => $pic});
 

--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -197,7 +197,7 @@ sub find {
     my $q = $query || {};
     my $conn = $self->_database->_connection;
     my $ns = $self->full_name;
-    my $cursor = MongoDB::Cursor->new(
+    my $cursor = MongoDB::Cursor::->new(
 	_connection => $conn,
 	_ns => $ns,
 	_query => $q,
@@ -485,7 +485,7 @@ sub ensure_index {
         Carp::croak("you're using the old ensure_index format, please upgrade");
     }
 
-    my $obj = Tie::IxHash->new("ns" => $ns, "key" => $keys);
+    my $obj = Tie::IxHash::->new("ns" => $ns, "key" => $keys);
 
     if (exists $options->{name}) {
         $obj->Push("name" => $options->{name});
@@ -513,12 +513,12 @@ sub _make_safe {
     my $conn = $self->_database->_connection;
     my $db = $self->_database->name;
 
-    my $last_error = Tie::IxHash->new(getlasterror => 1, w => $conn->w, wtimeout => $conn->wtimeout);
+    my $last_error = Tie::IxHash::->new(getlasterror => 1, w => $conn->w, wtimeout => $conn->wtimeout);
     my ($query, $info) = MongoDB::write_query($db.'.$cmd', 0, 0, -1, $last_error);
 
     $conn->send("$req$query");
 
-    my $cursor = MongoDB::Cursor->new(_ns => $info->{ns}, _connection => $conn, _query => {});
+    my $cursor = MongoDB::Cursor::->new(_ns => $info->{ns}, _connection => $conn, _query => {});
     $cursor->_init;
     $cursor->_request_id($info->{'request_id'});
 

--- a/lib/MongoDB/Connection.pm
+++ b/lib/MongoDB/Connection.pm
@@ -40,11 +40,11 @@ By default, it connects to a single server running on the local machine
 listening on the default port:
 
     # connects to localhost:27017
-    my $connection = MongoDB::Connection->new;
+    my $connection = MongoDB::Connection::->new;
 
 It can connect to a database server running anywhere, though:
 
-    my $connection = MongoDB::Connection->new(host => 'example.com:12345');
+    my $connection = MongoDB::Connection::->new(host => 'example.com:12345');
 
 See the L</"host"> section for more options for connecting to MongoDB.
 
@@ -75,7 +75,7 @@ hosts listed.  If it cannot connect to any hosts, it will die.
 If a port is not specified for a given host, it will default to 27017. For
 example, to connecting to C<localhost:27017> and C<localhost:27018>:
 
-    $conn = MongoDB::Connection->new("host" => "mongodb://localhost,localhost:27018");
+    $conn = MongoDB::Connection::->new("host" => "mongodb://localhost,localhost:27018");
 
 This will succeed if either C<localhost:27017> or C<localhost:27018> are available.
 
@@ -276,7 +276,7 @@ has db_name => (
 =head2 query_timeout
 
     # set query timeout to 1 second
-    my $conn = MongoDB::Connection->new(query_timeout => 1000);
+    my $conn = MongoDB::Connection::->new(query_timeout => 1000);
 
     # set query timeout to 6 seconds
     $conn->query_timeout(6000);
@@ -289,7 +289,7 @@ L<MongoDB::Cursor/timeout>.
 
     $MongoDB::Cursor::timeout = 5000;
     # query timeout for $conn will be 5 seconds
-    my $conn = MongoDB::Connection->new;
+    my $conn = MongoDB::Connection::->new;
 
 A value of -1 will cause the driver to wait forever for responses and 0 will
 cause it to die immediately.
@@ -297,7 +297,7 @@ cause it to die immediately.
 This value overrides L<MongoDB::Cursor/timeout>.
 
     $MongoDB::Cursor::timeout = 1000;
-    my $conn = MongoDB::Connection->new(query_timeout => 10);
+    my $conn = MongoDB::Connection::->new(query_timeout => 10);
     # timeout for $conn is 10 milliseconds
 
 =cut
@@ -453,7 +453,7 @@ sub BUILD {
     foreach (@pairs) {
         $opts->{host} = "mongodb://$_";
 
-        $self->_servers->{$_} = MongoDB::Connection->new($opts);
+        $self->_servers->{$_} = MongoDB::Connection::->new($opts);
 
         next unless $self->auto_connect;
 
@@ -543,7 +543,7 @@ Returns a L<MongoDB::Database> instance for database with the given C<$name>.
 
 sub get_database {
     my ($self, $database_name) = @_;
-    return MongoDB::Database->new(
+    return MongoDB::Database::->new(
         _connection => $self,
         name        => $database_name,
     );
@@ -631,7 +631,7 @@ sub get_master {
             }
             for (@{$master->{'hosts'}}) {
                 if (!$self->_servers->{$_}) {
-                    $self->_servers->{$_} = MongoDB::Connection->new("host" => "mongodb://$_", %opts);
+                    $self->_servers->{$_} = MongoDB::Connection::->new("host" => "mongodb://$_", %opts);
                 }
             }
             $self->ts(time());
@@ -667,7 +667,7 @@ sub _old_stupid_paired_conn {
 
     # check the left host
     eval {
-        $left = MongoDB::Connection->new("host" => $self->left_host, "port" => $self->left_port, timeout => $self->timeout);
+        $left = MongoDB::Connection::->new("host" => $self->left_host, "port" => $self->left_port, timeout => $self->timeout);
     };
     if (!($@ =~ m/couldn't connect to server/)) {
         $master = $left->find_one('admin.$cmd', {ismaster => 1});
@@ -678,7 +678,7 @@ sub _old_stupid_paired_conn {
 
     # check the right_host
     eval {
-        $right = MongoDB::Connection->new("host" => $self->right_host, "port" => $self->right_port, timeout => $self->timeout);
+        $right = MongoDB::Connection::->new("host" => $self->right_host, "port" => $self->right_port, timeout => $self->timeout);
     };
     if (!($@ =~ m/couldn't connect to server/)) {
         $master = $right->find_one('admin.$cmd', {ismaster => 1});

--- a/lib/MongoDB/Database.pm
+++ b/lib/MongoDB/Database.pm
@@ -105,7 +105,7 @@ database.
 
 sub get_collection {
     my ($self, $collection_name) = @_;
-    return MongoDB::Collection->new(
+    return MongoDB::Collection::->new(
         _database => $self,
         name      => $collection_name,
     );
@@ -127,7 +127,7 @@ sub get_gridfs {
     my ($self, $prefix) = @_;
     $prefix = "fs" unless $prefix;
 
-    return MongoDB::GridFS->new(
+    return MongoDB::GridFS::->new(
         _database => $self,
         prefix => $prefix
     );
@@ -256,7 +256,7 @@ See L<MongoDB::Connection/w> for more information.
 sub last_error {
     my ($self, $options) = @_;
 
-    my $cmd = Tie::IxHash->new("getlasterror" => 1);
+    my $cmd = Tie::IxHash::->new("getlasterror" => 1);
     if ($options) {
         $cmd->Push("w", $options->{w}) if $options->{w};
         $cmd->Push("wtimeout", $options->{wtimeout}) if $options->{wtimeout};

--- a/lib/MongoDB/GridFS.pm
+++ b/lib/MongoDB/GridFS.pm
@@ -33,7 +33,7 @@ MongoDB::GridFS - A file storage utility
     use MongoDB::GridFS;
 
     my $grid = $database->get_gridfs;
-    my $fh = IO::File->new("myfile", "r");
+    my $fh = IO::File::->new("myfile", "r");
     $grid->insert($fh, {"filename" => "mydbfile"});
 
 There are two interfaces for GridFS: a file-system/collection-like interface
@@ -117,8 +117,8 @@ sub _ensure_indexes {
     my $self = shift;
 
     # ensure the necessary index is present (this may be first usage)
-    $self->files->ensure_index(Tie::IxHash->new(filename => 1), {"safe" => 1});
-    $self->chunks->ensure_index(Tie::IxHash->new(files_id => 1, n => 1), {"safe" => 1});
+    $self->files->ensure_index(Tie::IxHash::->new(filename => 1), {"safe" => 1});
+    $self->chunks->ensure_index(Tie::IxHash::->new(files_id => 1, n => 1), {"safe" => 1});
 }
 
 =head1 METHODS
@@ -183,7 +183,7 @@ sub find_one {
 
     my $file = $self->files->find_one($criteria, $fields);
     return undef unless $file;
-    return MongoDB::GridFS::File->new({_grid => $self,info => $file});
+    return MongoDB::GridFS::File::->new({_grid => $self,info => $file});
 }
 
 =head2 remove ($criteria?, $options?)
@@ -261,7 +261,7 @@ with:
     open($basic_fh, '<', \$very_long_string);
 
     # turn the file handle into a FileHandle
-    my $fh = FileHandle->new;
+    my $fh = FileHandle::->new;
     $fh->fdopen($basic_fh, 'r');
 
     $gridfs->insert($fh);
@@ -284,7 +284,7 @@ sub insert {
         $id = $metadata->{"_id"};
     }
     else {
-        $id = MongoDB::OID->new;
+        $id = MongoDB::OID::->new;
     }
 
     my $n = 0;
@@ -304,7 +304,7 @@ sub insert {
 
     # compare the md5 hashes
     if ($options->{safe}) {
-        my $md5 = Digest::MD5->new;
+        my $md5 = Digest::MD5::->new;
         $md5->addfile($fh);
         my $digest = $md5->hexdigest;
         if ($digest ne $result->{md5}) {
@@ -352,7 +352,7 @@ sub all {
 
     my $cursor = $self->files->query;
     while (my $meta = $cursor->next) {
-        push @ret, MongoDB::GridFS::File->new(
+        push @ret, MongoDB::GridFS::File::->new(
             _grid => $self,
             info => $meta);
     }

--- a/lib/MongoDB/GridFS/File.pm
+++ b/lib/MongoDB/GridFS/File.pm
@@ -31,7 +31,7 @@ MongoDB::GridFS::File - A Mongo GridFS file
 
     use MongoDB::GridFS::File;
 
-    my $outfile = IO::File->new("outfile", "w");
+    my $outfile = IO::File::->new("outfile", "w");
     my $file = $grid->find_one;
     $file->print($outfile);
 
@@ -77,7 +77,7 @@ sub print {
     my ($written, $pos) = (0, 0);
     my $start_pos = $fh->getpos();
 
-    $self->_grid->chunks->ensure_index(Tie::IxHash->new(files_id => 1, n => 1));
+    $self->_grid->chunks->ensure_index(Tie::IxHash::->new(files_id => 1, n => 1));
 
     my $cursor = $self->_grid->chunks->query({"files_id" => $self->info->{"_id"}})->sort({"n" => 1});
 

--- a/lib/MongoDB/OID.pm
+++ b/lib/MongoDB/OID.pm
@@ -40,8 +40,8 @@ saved document:
 To create a copy of an existing OID, you must set the value attribute in the
 constructor.  For example:
 
-    my $id1 = MongoDB::OID->new;
-    my $id2 = MongoDB::OID->new(value => $id1->value);
+    my $id1 = MongoDB::OID::->new;
+    my $id2 = MongoDB::OID::->new(value => $id1->value);
 
 Now C<$id1> and C<$id2> will have the same value.
 
@@ -118,11 +118,11 @@ sub get_time {
 
 =head2 TO_JSON
 
-    my $json = JSON->new;
+    my $json = JSON::->new;
     $json->allow_blessed;
     $json->convert_blessed;
 
-    $json->encode(MongoDB::OID->new);
+    $json->encode(MongoDB::OID::->new);
 
 Returns a JSON string for this OID.  This is compatible with the strict JSON
 representation used by MongoDB, that is, an OID with the value 

--- a/t/auth.pl
+++ b/t/auth.pl
@@ -16,7 +16,7 @@ use File::Slurp;
 use Tie::IxHash;
 use FileHandle;
 
-my $conn = MongoDB::Connection->new("username" => "kristina", "password" => "foo", "db_name" => "bar", "ssl" => $ENV{MONGO_SSL});
+my $conn = MongoDB::Connection::->new("username" => "kristina", "password" => "foo", "db_name" => "bar", "ssl" => $ENV{MONGO_SSL});
 
 my $db = $conn->get_database("bar");
 my $c = $db->get_collection("x");

--- a/t/memtest.pl
+++ b/t/memtest.pl
@@ -7,7 +7,7 @@ use DateTime;
 
 use MongoDB;
 
-my $conn = MongoDB::Connection->new(ssl => $ENV{MONGO_SSL});
+my $conn = MongoDB::Connection::->new(ssl => $ENV{MONGO_SSL});
 my $db   = $conn->get_database('test_database');
 my $coll = $db->get_collection('test_collection');
 

--- a/t/paired.pl
+++ b/t/paired.pl
@@ -7,9 +7,9 @@ use MongoDB::OID;
 use Devel::Peek;
 use Data::Dump;
 
-my $m = MongoDB::Connection->new(left_host => "localhost", left_port => 27017, 
-                                 right_host => "localhost", right_port => 27018,
-                                 ssl => $ENV{MONGO_SSL});
+my $m = MongoDB::Connection::->new(left_host => "localhost", left_port => 27017, 
+                                   right_host => "localhost", right_port => 27018,
+                                   ssl => $ENV{MONGO_SSL});
 
 my $db = $m->get_database("foo");
 my $c = $db->get_collection("bar");

--- a/t/rs.pl
+++ b/t/rs.pl
@@ -7,7 +7,7 @@ use MongoDB::OID;
 use Devel::Peek;
 use Data::Dump;
 
-my $m = MongoDB::Connection->new(host => "mongodb://localhost:27018", find_master => 1, ssl => $ENV{MONGO_SSL});
+my $m = MongoDB::Connection::->new(host => "mongodb://localhost:27018", find_master => 1, ssl => $ENV{MONGO_SSL});
 
 my $db = $m->get_database("admin");
 my $c = $db->get_collection("bar");


### PR DESCRIPTION
Protect against cases like user code defining sub JSON, though primarily
this is a style patch.
