### PR TITLE
sometimes floats persist as ints

### DIFF
--- a/perl_mongo.c
+++ b/perl_mongo.c
@@ -1406,6 +1406,13 @@ append_sv (buffer *buf, const char *key, SV *sv, stackette *stack, int is_insert
     case SVt_PVIV:
     case SVt_PVLV:
     case SVt_PVMG: {
+      if ((aggressively_number & IS_NUMBER_NOT_INT) || (!is_string && SvNOK(sv))) {
+        set_type(buf, BSON_DOUBLE);
+        perl_mongo_serialize_key(buf, key, is_insert);
+        perl_mongo_serialize_double(buf, (double)SvNV (sv));
+        break;
+      }
+
       // if it's publicly an int OR (privately an int AND not publicly a string)
       if (aggressively_number || (!is_string && (SvIOK(sv) || (SvIOKp(sv) && !SvPOK(sv))))) {
 #if defined(USE_64_BIT_INT)


### PR DESCRIPTION
Fix for this bug:   https://rt.cpan.org/Public/Bug/Display.html?id=77267

From that bug report:

It turns out that if you take a scalar that holds a float, use it as an int, store it 
as the value for a Moose attribute, insert the value of the Moose attribute into 
Mongo, then it's stored as a NumberLong instead of a float inside Mongo.

All those steps cause the about-to-be-inserted scalar to look like this according to 
Devel::Peek:

SV = PVMG(0x21b8630) at 0x21abf98
  REFCNT = 1
  FLAGS = (PADMY,NOK,pIOK,pNOK)
  IV = 1
  NV = 1.25
  PV = 0

Apparently, under these circumstances MongoDB is choosing to pass the IV to Mongo 
instead of the NV.  This seems like the wrong choice.
