### PR TITLE
PERL-167 Tailable cursor

### DIFF
--- a/lib/MongoDB/Cursor.pm
+++ b/lib/MongoDB/Cursor.pm
@@ -135,6 +135,7 @@ has _tailable => (
     default => 0,
 );
 
+
 =head2 immortal
 
     $cursor->immortal(1);
@@ -318,7 +319,7 @@ sub limit {
 }
 
 
-=head2 tailable ($num)
+=head2 tailable ($bool)
 
     $cursor->query->tailable(1);
 
@@ -329,6 +330,8 @@ returning new results as more is added to a collection.
 They are often used for getting log messages.
 
 Boolean value, defaults to 0.
+
+Returns this cursor for chaining operations.
 
 =cut
 

--- a/t/cursor.t
+++ b/t/cursor.t
@@ -19,7 +19,7 @@ if ($@) {
     plan skip_all => $@;
 }
 else {
-    plan tests => 71;
+    plan tests => 74;
 }
 
 my $db = $conn->get_database('test_database');
@@ -208,10 +208,24 @@ is($coll->query->limit(1)->skip(1)->count(1), 1, 'count limit & skip');
 {
     my $cursor = $coll->find();
 
+	$cursor = $cursor->tailable(1);
+	is($cursor->_tailable, 1);
+	$cursor = $cursor->tailable(0);
+	is($cursor->_tailable, 0);
+
     $cursor = $coll->find()->tailable(1);
     is($cursor->_tailable, 1);
     $cursor = $coll->find()->tailable(0);
     is($cursor->_tailable, 0);
+    
+    #test is actual cursor
+    $coll->drop;
+    $coll->insert({"x" => 1});
+    $cursor = $coll->find()->tailable(0);
+    my $doc = $cursor->next;
+    is($doc->{'x'}, 1);
+    
+	$cursor = $coll->find();
 
     $cursor->immortal(1);
     is($cursor->immortal, 1);


### PR DESCRIPTION
This commit allows for the cursor to be set to tailable via a method in addition to a field.
