### PR TITLE
Ablitity to set "w" parameter to a string in Connection.pm 

### DIFF
--- a/lib/MongoDB/Connection.pm
+++ b/lib/MongoDB/Connection.pm
@@ -16,7 +16,6 @@
 
 package MongoDB::Connection;
 
-
 # ABSTRACT: A connection to a Mongo server
 
 use MongoDB;
@@ -136,11 +135,19 @@ safe insert times out and croaks.
 
 =back
 
+I<MongoDB server version 2.0+: "majority" and Data Center Awareness>
+
+As of MongoDB 2.0+, the 'w' parameter can be passed strings. This can be done by passing it the string "majority" this will wait till the B<majority> of 
+of the nodes in the relica set have recieved the data. For more information see: http://www.mongodb.org/display/DOCS/getLastError+Command#getLastErrorCommand-majority
+
+This can be useful for "Data Center Awareness." In v2.0+, you can "tag" replica members. With "tagging" you can specify a new "getLastErrorMode" where you can create new
+rules on how your data is replicated. To used you getLastErrorMode, you pass in the name of the mode to the 'w' parameter. For more infomation see: http://www.mongodb.org/display/DOCS/Data+Center+Awareness
+
 =cut
 
 has w => (
     is      => 'rw',
-    isa     => 'Int',
+    isa     => 'Int|Str',
     default => 1,
 );
 

--- a/t/connection.t
+++ b/t/connection.t
@@ -20,7 +20,7 @@ if ($@) {
     plan skip_all => $@;
 }
 else {
-    plan tests => 19;
+    plan tests => 21;
 }
 
 throws_ok {
@@ -77,10 +77,15 @@ is($result->{'ok'}, 1, 'db was dropped');
 
 
 # w
-SKIP: {
+{
     is($conn->w, 1, "get w");
     $conn->w(3);
     is($conn->w, 3, "set w");
+
+    $conn->w("tag");
+    is($conn->w, "tag", "set w to string");
+
+    dies_ok { $conn->w({tag => 1});} "Setting w to anything but a string or int dies.";
 
     is($conn->wtimeout, 1000, "get wtimeout");
     $conn->wtimeout(100);


### PR DESCRIPTION
We need the ability to set the "w" parameter to a string. This is becaues as of 2.0, we can tell it to replicate to the "majority" of the nodes. Plus with tagging and data center awareness, we can create new "getLastErrorModes" to say who we want the data to replicate. Here are the docs about it:
http://www.mongodb.org/display/DOCS/getLastError+Command#getLastErrorCommand-majority
http://www.mongodb.org/display/DOCS/Data+Center+Awareness

I already created a bug report for it this time :)

https://jira.mongodb.org/browse/PERL-184

Thanks.
