### PR TITLE
Relax a string test pattern; Use like instead of ok.

### DIFF
--- a/t/db.t
+++ b/t/db.t
@@ -43,7 +43,7 @@ my $hello = $db->eval('function(x) { return "hello, "+x; }', ["world"]);
 is('hello, world', $hello, 'db eval');
 
 my $err = $db->eval('function(x) { xreturn "hello, "+x; }', ["world"]);
-ok($err =~ /compile failed: JS Error/, 'js err');
+like($err, qr/compile failed/, 'js err');
 
 # tie
 {


### PR DESCRIPTION
On Fedora 18 with MongoDB 2.2.1, the test 'js err' in t/db.t produced much
more verbose output and the pattern miss-matched.
