### PR TITLE
MongoDB::Cursor::hint() requires ordered hashes.

### DIFF
--- a/lib/MongoDB/Cursor.pm
+++ b/lib/MongoDB/Cursor.pm
@@ -408,7 +408,7 @@ sub hint {
     confess "cannot set hint after querying"
 	if $self->started_iterating;
     confess 'not a hash reference'
-	unless ref $index eq 'HASH';
+    	unless ref $index eq 'HASH' || ref $index eq 'Tie::IxHash';
 
     $self->_ensure_special;
     $self->_query->{'$hint'} = $index;


### PR DESCRIPTION
+1 - Currently a performance impacting issue.

Hash order is important, otherwise the driver reports as a "bad hint" as order is not maintained.

I believe there are other issues underlying this.  In the MongoDB shell, executing a sampe query with the hint runs 4 times faster than without, but running it through the perl driver there is no speed increase (290ms with hint vs. 1343ms w/o hint - averaged over 100 requests).
