### PR TITLE
Fix hash ordering bugs

### DIFF
--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -409,7 +409,7 @@ sub find_and_modify {
     my $conn = $self->_database->_client;
     my $db   = $self->_database;
 
-    my $result = $db->run_command( { findAndModify => $self->name, %$opts } );
+    my $result = $db->run_command( [ findAndModify => $self->name, %$opts ] );
 
     if ( not $result->{ok} ) { 
         return if ( $result->{errmsg} eq 'No matching object found' );
@@ -435,7 +435,7 @@ sub aggregate {
 
     my $db   = $self->_database;
 
-    my $result = $db->run_command( { aggregate => $self->name, pipeline => $pipeline } );
+    my $result = $db->run_command( [ aggregate => $self->name, pipeline => $pipeline ] );
 
     # TODO: handle errors?
 
@@ -691,10 +691,10 @@ sub count {
 
     my $obj;
     eval {
-        $obj = $self->_database->run_command({
+        $obj = $self->_database->run_command([
             count => $self->name,
             query => $query,
-        });
+        ]);
     };
 
     # if there was an error, check if it was the "ns missing" one that means the
@@ -760,9 +760,10 @@ Use C<MongoDB::Collection::get_indexes> to find the index name.
 
 sub drop_index {
     my ($self, $index_name) = @_;
-    my $t = tie(my %myhash, 'Tie::IxHash');
-    %myhash = ("deleteIndexes" => $self->name, "index" => $index_name);
-    return $self->_database->run_command($t);
+    return $self->_database->run_command([
+        deleteIndexes => $self->name,
+        index => $index_name,
+    ]);
 }
 
 =head2 get_indexes

--- a/lib/MongoDB/GridFS.pm
+++ b/lib/MongoDB/GridFS.pm
@@ -345,7 +345,7 @@ sub _calc_md5 {
     my ($self, $id, $root, $retry) = @_;
    
     # Try to get an md5 hash for the file
-    my $result = $self->_database->run_command({"filemd5", $id, "root" => $self->prefix});
+    my $result = $self->_database->run_command(["filemd5", $id, "root" => $self->prefix]);
     
     # If we didn't get a hash back, it means something is wrong (probably to do with gridfs's 
     # indexes because its currently the only error that is thown from the md5 class)

--- a/t/gridfs.t
+++ b/t/gridfs.t
@@ -53,7 +53,7 @@ is(0, $chunk->{'n'});
 is("$id", $chunk->{'files_id'}."", "compare returned id");
 is($dumb_str, $chunk->{'data'}, "compare file content");
 
-my $md5 = $db->run_command({"filemd5" => $chunk->{'files_id'}, "root" => "fs"});
+my $md5 = $db->run_command(["filemd5" => $chunk->{'files_id'}, "root" => "fs"]);
 my $file = $grid->files->find_one();
 ok($file->{'md5'} ne 'd41d8cd98f00b204e9800998ecf8427e', $file->{'md5'});
 is($file->{'md5'}, $md5->{'md5'}, $md5->{'md5'});


### PR DESCRIPTION
MongoDB requires the command to come before the arguments, but this
isn't guaranteed when passing a hashref to ->run_command. Use an
arrayref for commands with arguments to make sure the order gets right.
