### PR TITLE
Fix mangled merge of UTF-8 vs. 'local' test changes 

### DIFF
--- a/t/collection.t
+++ b/t/collection.t
@@ -25,7 +25,7 @@ if ($@) {
     plan skip_all => $@;
 }
 else {
-    plan tests => 140;
+    plan tests => 141;
 }
 
 my $db = $conn->get_database('test_database');
@@ -204,12 +204,22 @@ $coll->drop;
     delete $utfblah->{_id};
     is_deeply($utfblah, $copy, 'non-ascii values');
 
+    $coll->drop;
+
+    $insert = { $down => "down", $up => "up", $non_latin => "non_latin" };
+    $copy = +{ %{$insert} };
+    $coll->insert($insert);
+    $utfblah = $coll->find_one;
+    delete $utfblah->{_id};
+    is_deeply($utfblah, $copy, 'non-ascii keys');
+}
+
 {
 local $MongoDB::BSON::utf8_flag_on = 0;
 $coll->drop;
-$coll->insert({"\x9F" => "hi"});
-$utfblah = $coll->find_one;
-is($utfblah->{chr(159)}, "hi", 'translate non-utf8 key');
+$coll->insert({"\xe9" => "hi"});
+my $utfblah = $coll->find_one;
+is($utfblah->{"\xC3\xA9"}, "hi", 'byte key');
 }
 
 $coll->drop;
@@ -477,12 +487,12 @@ SKIP: {
     # turn off utf8 flag now
     local $MongoDB::BSON::utf8_flag_on = 0;
     $coll->insert({ foo => "\x{4e2d}\x{56fd}"});
-    $utfblah = $coll->find_one;
+    my $utfblah = $coll->find_one;
     # use utf8;
     my $utfv2 = encode('utf8',"\x{4e2d}\x{56fd}");
     # my $utfv2 = encode('utf8',"中国");
     # diag(Dumper(\$utfv2));
-    is($utfblah->{foo2},$utfv2,'turn utf8 flag off,return perl internal form(bytes)');
+    is($utfblah->{foo},$utfv2,'turn utf8 flag off,return perl internal form(bytes)');
     $coll->drop;
 }
 


### PR DESCRIPTION
The merge of the speedup branch clobbered some of the test changes for the UTF-8 fixes. This restores the union of the changes from both the branches
