### PR TITLE
added $MongoDB::VERSION so that MakeMaker wouldn't complain (VERSION was...

### DIFF
--- a/lib/MongoDB.pm
+++ b/lib/MongoDB.pm
@@ -19,6 +19,9 @@ use strict;
 use warnings;
 
 package MongoDB;
+{
+	$MongoDB::VERSION = '7.001.0';
+}
 # ABSTRACT: A MongoDB Driver for Perl
 
 use XSLoader;


### PR DESCRIPTION
... present in 7.000.0, but not in the current tree)

The CPAN repository is still showing 7.000.0 as the most current version so I went looking for the version mentioned on the mongodb website because I was running into the javascript test failures that are reportedly fixed in 7.000.1 and 7.001.0

I do know know why or when this package version line was removed, but restoring it, made MakeMaker happy and compiled and passed all the tests on OpenSuSE and Mac OS X 10.8
