### PR TITLE
Fix specifying index keys as an array ref

### DIFF
--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -135,13 +135,11 @@ sub to_index_string {
     my $keys = shift;
 
     my @name;
-    if (ref $keys eq 'ARRAY' ||
-        ref $keys eq 'HASH' ) {
-
-        while ((my $idx, my $d) = each(%$keys)) {
-            push @name, $idx;
-            push @name, $d;
-        }
+    if (ref $keys eq 'ARRAY') {
+        @name = @$keys;
+    }
+    elsif (ref $keys eq 'HASH' ) {
+        @name = %$keys
     }
     elsif (ref $keys eq 'Tie::IxHash') {
         my @ks = $keys->Keys;
@@ -592,6 +590,7 @@ sub ensure_index {
         Carp::croak("you're using the old ensure_index format, please upgrade");
     }
 
+    $keys = Tie::IxHash->new(@$keys) if ref $keys eq 'ARRAY';
     my $obj = Tie::IxHash->new("ns" => $ns, "key" => $keys);
 
     if (exists $options->{name}) {

--- a/t/collection.t
+++ b/t/collection.t
@@ -144,7 +144,7 @@ $coll->drop;
 {
     $ok = $coll->ensure_index({foo => 1, bar => -1, baz => 1});
     ok(!defined $ok);
-    $ok = $coll->ensure_index({foo => 1, bar => 1});
+    $ok = $coll->ensure_index([foo => 1, bar => 1]);
     ok(!defined $ok);
     $coll->insert({foo => 1, bar => 1, baz => 1, boo => 1});
     $coll->insert({foo => 1, bar => 1, baz => 1, boo => 2});


### PR DESCRIPTION
- Turn array refs into Tie::IxHash objects before inserting them
- Handle array refs correctly in to_index_string()
