### PR TITLE
Prevent calculation on MD5 when 'safe' is not set

### DIFF
--- a/lib/MongoDB/GridFS.pm
+++ b/lib/MongoDB/GridFS.pm
@@ -310,13 +310,15 @@ sub insert {
     }
     $fh->setpos($start_pos);
 
-    # get an md5 hash for the file. set the retry flag to 'true' incase the 
-    # database, collection, or indexes are missing. That way we can recreate them 
-    # retry the md5 calc.
-    my $result = $self->_calc_md5($id, $self->prefix, 1);
-
+    my %copy = %{$metadata};
     # compare the md5 hashes
     if ($options->{safe}) {
+        # get an md5 hash for the file. set the retry flag to 'true' incase the 
+        # database, collection, or indexes are missing. That way we can recreate them 
+        # retry the md5 calc.
+        my $result = $self->_calc_md5($id, $self->prefix, 1);
+        $copy{"md5"} = $result->{"md5"};
+
         my $md5 = Digest::MD5->new;
         $md5->addfile($fh);
         my $digest = $md5->hexdigest;
@@ -327,9 +329,7 @@ sub insert {
         }
     }
 
-    my %copy = %{$metadata};
     $copy{"_id"} = $id;
-    $copy{"md5"} = $result->{"md5"};
     $copy{"chunkSize"} = $MongoDB::GridFS::chunk_size;
     $copy{"uploadDate"} = DateTime->now;
     $copy{"length"} = $length;


### PR DESCRIPTION
When 'safe' flag is not set, MD5 sum shouldn't be calculated. Especially on the server, because it does one more query which the user can try to prevent.
