### PR TITLE
PERL-267 memory leak fixes. plus, making sure libson is linked when buil...

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,8 @@ if ( $ENV{PERL_MONGODB_WITH_SASL} || grep { $_ eq '--sasl' } @ARGV ) {
     push @cc_optimize_flags, '-DMONGO_SASL';
 }
 
+push @cc_lib_links, 'bson-1.0';
+
 cc_lib_links( @cc_lib_links ) if @cc_lib_links;
 cc_optimize_flags( @cc_optimize_flags ) if @cc_optimize_flags;
 

--- a/mongo_link.c
+++ b/mongo_link.c
@@ -141,15 +141,18 @@ void perl_mongo_connect(SV *client, mongo_link* link) {
   link->sender = non_ssl_send;
   link->receiver = non_ssl_recv;
 
-  IV sasl_flag = SvIV( perl_mongo_call_method( client, "sasl", 0, 0 ) );
+  SV* sasl_flag = perl_mongo_call_method( client, "sasl", 0, 0 );
 
-  if ( sasl_flag == 1 ) { 
+  if ( SvIV(sasl_flag) == 1 ) { 
 #ifdef MONGO_SASL
       sasl_authenticate( client, link );
 #else
       croak( "MongoDB: sasl => 1 specified, but this driver was not compiled with SASL support\n" );
 #endif
   }
+  
+  SvREFCNT_dec(sasl_flag);
+  
 }
 
 /*

--- a/xs/MongoClient.xs
+++ b/xs/MongoClient.xs
@@ -163,8 +163,7 @@ connect (self)
      SV *self
    PREINIT:
      mongo_link *link = (mongo_link*)perl_mongo_get_ptr_from_instance(self, &connection_vtbl);
-     SV *username, *password;
-     IV sasl_flag;
+     SV *username, *password, *sasl_flag;
    CODE:
     perl_mongo_connect(self, link);
 
@@ -175,9 +174,9 @@ connect (self)
      // try legacy authentication if we have username and password but are not using SASL 
      username = perl_mongo_call_reader (self, "username");
      password = perl_mongo_call_reader (self, "password");
-     sasl_flag = SvIV( perl_mongo_call_reader( self, "sasl" ) );
+     sasl_flag = perl_mongo_call_reader( self, "sasl" );
 
-     if ( ( sasl_flag == 0 ) && SvPOK(username) && SvPOK(password)) {
+     if ( ( SvIV(sasl_flag) == 0 ) && SvPOK(username) && SvPOK(password)) {
        SV *database, *result, **ok;
 
        database = perl_mongo_call_reader (self, "db_name");
@@ -186,6 +185,7 @@ connect (self)
          SvREFCNT_dec(database);
          SvREFCNT_dec(username);
          SvREFCNT_dec(password);
+         SvREFCNT_dec(sasl_flag);
          croak("authentication returned no result");
        }
        // we're expecting either a string (failure) or a hash (success hopefully)
@@ -193,6 +193,7 @@ connect (self)
          SvREFCNT_dec(database);
          SvREFCNT_dec(username);
          SvREFCNT_dec(password);
+         SvREFCNT_dec(sasl_flag);
          croak("%s", SvPV_nolen(result));
        } else if (SvROK(result)) {
          ok = hv_fetchs((HV*)SvRV(result), "ok", 0);
@@ -200,6 +201,7 @@ connect (self)
            SvREFCNT_dec(database);
            SvREFCNT_dec(username);
            SvREFCNT_dec(password);
+           SvREFCNT_dec(sasl_flag);
            croak ("couldn't authenticate with server");
          }
        } else {
@@ -207,6 +209,7 @@ connect (self)
          SvREFCNT_dec(database);
          SvREFCNT_dec(username);
          SvREFCNT_dec(password);
+         SvREFCNT_dec(sasl_flag);
          croak("something weird happened with authentication");
        }
 
@@ -215,6 +218,7 @@ connect (self)
 
      SvREFCNT_dec(username);
      SvREFCNT_dec(password);
+     SvREFCNT_dec(sasl_flag);
 
 
 int


### PR DESCRIPTION
PERL-267
https://jira.mongodb.org/browse/PERL-267

This at least fixes some of the memory leaks. When doing and endless loop of inserts, I saw no memory growth after this. There was a couple of leaks in setting up a connection, and in the cursor. I also fixed up the Makefile.PL to make sure that libson was linked in. 

I hope this at least helps. 
