### PR TITLE
add [Encoding] section to dist.ini for t/img.png

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,3 +55,7 @@ push_to         = origin
 
 [UploadToCPAN]
 ;[FakeRelease]
+
+[Encoding]
+encoding = bytes
+filename = t/img.png


### PR DESCRIPTION
per https://github.com/rjbs/Dist-Zilla/issues/270

As I've now figured out this repo uses Dist::Zilla, and got it it to build correctly, the following won't happen again! https://github.com/mongodb/mongo-perl-driver/commit/ad2fd9c3cf50d15eaebfe9939913c0b6091eae93

Note: I had to make and install libbson, and then add the following line to Makefile.PL to get things to work.   On https://github.com/mongodb/mongo-perl-driver/pull/85 you mentioned how you would integrate this to be a non-issue.
`cc_inc_paths( '/usr/local/include/libbson-1.0/' );`
