### PR TITLE
fix for count used with read_preference

### DIFF
--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -568,10 +568,10 @@ sub count {
 
     my $obj;
     try {
-        $obj = $self->_database->_try_run_command([
+        $obj = $self->_database->_try_run_command({
             count => $self->name,
             query => $query,
-        ]);
+        });
     }
     catch {
         # if there was an error, check if it was the "ns missing" one that means the


### PR DESCRIPTION
fix for "Not a HASH reference at /usr/local/lib/perl/5.10.1/MongoDB/Collection.pm line 121" when using count with read_preference
