### PR TITLE
request_id isn't thread safe

### DIFF
--- a/lib/MongoDB/BulkWrite.pm
+++ b/lib/MongoDB/BulkWrite.pm
@@ -622,7 +622,7 @@ sub _gen_legacy_insert {
     # $doc is a document to insert
 
     # for bulk, we don't accumulate IDs
-    my ( $insert, undef ) = MongoDB::write_insert( $ns, [$doc], 0 );
+    my ( $insert, undef ) = MongoDB::write_insert( $ns, [$doc], 0, ++$MongoDB::Cursor::_request_id );
 
     return $insert;
 }
@@ -635,14 +635,14 @@ sub _gen_legacy_update {
     $flags |= 1 << 0 if $doc->{upsert};
     $flags |= 1 << 1 if $doc->{multi};
 
-    return MongoDB::write_update( $ns, $doc->{q}, $doc->{u}, $flags );
+    return MongoDB::write_update( $ns, $doc->{q}, $doc->{u}, $flags, ++$MongoDB::Cursor::_request_id );
 }
 
 sub _gen_legacy_delete {
     my ( $self, $ns, $doc ) = @_;
     # $doc is { q: $query, limit: $limit }
 
-    return MongoDB::write_remove( $ns, $doc->{q}, $doc->{limit} ? 1 : 0 );
+    return MongoDB::write_remove( $ns, $doc->{q}, $doc->{limit} ? 1 : 0, ++$MongoDB::Cursor::_request_id );
 }
 
 sub _check_no_dollar_keys {

--- a/lib/MongoDB/Cursor.pm
+++ b/lib/MongoDB/Cursor.pm
@@ -28,6 +28,8 @@ use MongoDB::Error;
 use boolean;
 use Tie::IxHash;
 use namespace::clean -except => 'meta';
+use threads;
+use threads::shared;
 
 =head1 NAME
 
@@ -53,7 +55,7 @@ Core documentation on cursors: L<http://dochub.mongodb.org/core/cursors>.
 
 =cut
 
-$MongoDB::Cursor::_request_id = int(rand(1000000));
+our $_request_id : shared = int(rand(1000000));
 
 =head1 STATIC ATTRIBUTES
 
@@ -286,8 +288,9 @@ sub _do_query {
         ($self->immortal << 4) |
         ($self->partial << 7);
 
-    my ($query, $info) = MongoDB::write_query($self->_ns, $opts, $self->_skip, $self->_limit || $self->_batch_size, $self->_query, $self->_fields);
-    $self->_request_id($info->{'request_id'});
+    my $request_id = ++$MongoDB::Cursor::_request_id;
+    my ($query, $info) = MongoDB::write_query($self->_ns, $opts, $self->_skip, $self->_limit || $self->_batch_size, $self->_query, $self->_fields, $request_id);
+    $self->_request_id( $request_id );
 
     if ( length($query) > $self->_client->_max_bson_wire_size ) {
         MongoDB::_CommandSizeError->throw(

--- a/mongo_link.h
+++ b/mongo_link.h
@@ -82,12 +82,10 @@
   header.op = opcode;
 
 #define CREATE_RESPONSE_HEADER(buf, ns, rto, opcode)    \
-  sv_setiv(request_id, SvIV(request_id)+1);             \
   CREATE_MSG_HEADER(SvIV(request_id), rto, opcode);     \
   APPEND_HEADER_NS(buf, ns, 0);
 
 #define CREATE_HEADER_WITH_OPTS(buf, ns, opcode, opts)  \
-  sv_setiv(request_id, SvIV(request_id)+1);             \
   CREATE_MSG_HEADER(SvIV(request_id), 0, opcode);       \
   APPEND_HEADER_NS(buf, ns, opts);
 

--- a/t/threads/basic.t
+++ b/t/threads/basic.t
@@ -56,11 +56,11 @@ $col->drop;
     my @threads = map {
         threads->create(sub {
             my $col = $conn->get_database($testdb->name)->get_collection('kooh');
-            $col->insert({ foo => threads->self->tid }, { safe => 1 });
+            map { $col->insert({ foo => threads->self->tid }, { safe => 1 }) } 0..999;
         })
-    } 0 .. 9;
+    } 0 .. 99;
 
-    my @vals = map { $_->tid } @threads;
+    my @vals = map { ( $_->tid ) x 1000 } @threads;
     my @ids = map { $_->join } @threads;
 
     is scalar keys %{ { map { ($_ => 1) } @ids } }, scalar @ids,


### PR DESCRIPTION
The way request ids are generated isn't thread safe.

In particular having a global static SV * variable (i.e. static SV * request_id) is wrong

I managed to trigger the race condition in the test case by increasing the number of threads and the number of inserts.

Made a quick fix, by using a Perl shared variable and passing the value to the corresponding functions.