### PR TITLE
Fix MinGW compile with ActivePerl 64-bit 5.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ MongoDB-*
 META.yml
 pod/*
 config.log
+dll.base
+dll.exp
+MYMETA.json
+MYMETA.yml
+output.txt


### PR DESCRIPTION
Added missing declarations to fix local compilation with PPM MinGW 4.5.4
and all PPM prerequisites except Authen-SCRAM. Authen-SCRAM 0.003 builds
and installs with MinGW.
