### PR TITLE
Fixed the code markup

### DIFF
--- a/lib/MongoDB/Examples.pod
+++ b/lib/MongoDB/Examples.pod
@@ -62,11 +62,11 @@ retrieved by using C<get_database>. See L<MongoDB::MongoClient> for more.
 
     $db->get_collection( 'users' )->find( { age => 33 } )->sort( { name => 1 } );
 
-=item C<<SELECT * FROM users WHERE age>33>>
+=item C<< SELECT * FROM users WHERE age>33 >>
 
     $db->get_collection( 'users' )->find( { age => { '$gt' => 33 } } );
 
-=item C<<SELECT * FROM users WHERE age<33>>
+=item C<< SELECT * FROM users WHERE age<33 >>
 
     $db->get_collection( 'users' )->find( { age => { '$lt' => 33 } } );
 
@@ -78,7 +78,7 @@ retrieved by using C<get_database>. See L<MongoDB::MongoClient> for more.
 
     $db->get_collection( 'users' )->find( {name => qr/^Joe/ } );
 
-=item C<<SELECT * FROM users WHERE age>33 AND age<=40>>
+=item C<< SELECT * FROM users WHERE age>33 AND age<=40 >>
 
     $db->get_collection( 'users' )->find( { age => { '$gt' => 33, '$lte' => 40 } } );
 
@@ -125,7 +125,7 @@ C<ensureIndex>.
 
     $db->get_collection( 'users' )->count;
 
-=item C<<SELECT COUNT(*y) FROM users where age > 30>>
+=item C<< SELECT COUNT(*y) FROM users where age > 30 >>
 
     $db->get_collection( 'users' )->find( { "age" => { '$gt' => 30 } } )->count;
 


### PR DESCRIPTION
Since there is no space between the '>>' delimiters the pod markup was wrong for some queries that had used it