### PR TITLE
Fix incorrect variable; caused spurious MongoDB::SelectionError

### DIFF
--- a/lib/MongoDB/_Topology.pm
+++ b/lib/MongoDB/_Topology.pm
@@ -527,7 +527,7 @@ sub _get_server_link {
         $self->check_address($address);
 
         # topology might have dropped the server
-        $server = $self->servers->{addresses}
+        $server = $self->servers->{$address}
           or return;
 
         my $fresh_link = $self->links->{$address};


### PR DESCRIPTION
Typo on variable name causes idle connection refreshes to fail and throw "MongoDB::SelectionError: Server <servername> is no longer available."