### PR TITLE
fsync test skips on inMemory storage engine

### DIFF
--- a/t/fsync.t
+++ b/t/fsync.t
@@ -34,6 +34,11 @@ my $conn = build_client();
 my $server_type = server_type( $conn );
 my $server_version = server_version( $conn );
 
+my $server_status_res = $conn->send_admin_command([serverStatus => 1]);
+my $storage_engine = $server_status_res->{output}->{storageEngine};
+plan skip_all => "fsync not supported for inMemory storage engine"
+    if $storage_engine->{name} =~ qr/inMemory/;
+
 my $ret;
 
 # Test normal fsync.


### PR DESCRIPTION
super simple patch to skip fsync.t on "inMemory" and "inMemoryExperiment" storage engines

-Rahul