### PR TITLE
Calculate "inserted_count"

### DIFF
--- a/lib/MongoDB/InsertManyResult.pm
+++ b/lib/MongoDB/InsertManyResult.pm
@@ -44,10 +44,16 @@ The number of documents inserted.
 =cut
 
 has inserted_count => (
-    is      => 'ro',
-    default => 0,
+    is      => 'lazy',
+    builder => '_build_inserted_count',
     isa => Num,
 );
+
+sub _build_inserted_count
+{
+    my ($self) = @_;
+    return scalar @{ $self->inserted };
+}
 
 =attr inserted
 

--- a/t/crud.t
+++ b/t/crud.t
@@ -116,6 +116,7 @@ subtest "insert_many" => sub {
         },
         "inserted_ids contains correct keys/values"
     );
+    is($res->inserted_count, 2, "Two docs inserted.");
 
     # ordered insert should halt on error
     $coll->drop;


### PR DESCRIPTION
Hello! I wrote some unit test code like

    my $res = $collection->insert_many(\@test_data);
    is($res->inserted_count, 3, 'Inserted three records');

And, weirdly, got undef back. According to $res->inserted, I successfully inserted three records. I looked at the code, and couldn't find anywhere that "inserted_count" was actually being set. And so, voila.

Let me know if there's anything I should change.

Cheers!