### PR TITLE
$MongoDB::Cursor::slave_ok -> $MongoDB::Cursor::slave_okay

### DIFF
--- a/lib/MongoDB/Upgrading.pod
+++ b/lib/MongoDB/Upgrading.pod
@@ -307,7 +307,7 @@ queries and query-like methods.
 
 The C<explain> cursor method no longer resets the cursor.
 
-The C<slave_ok> cursor method now sets the C<read_preference>
+The C<slave_okay> cursor method now sets the C<read_preference>
 to 'secondaryPreferred' or clears it to 'primary'.
 
 The C<snapshot> cursor method now requires a boolean argument, allowing

--- a/lib/MongoDB/Upgrading.pod
+++ b/lib/MongoDB/Upgrading.pod
@@ -317,7 +317,7 @@ an argument (as it was in v0) is a fatal exception.
 Parallel scan "cursors" are now L<QueryResult> objects, with the same
 iteration methods as in v0.
 
-The C<$MongoDB::Cursor::slave_ok> global variable has been removed as part
+The C<$MongoDB::Cursor::slave_okay> global variable has been removed as part
 of the revision to read preference handling.  See the L<read
 preferences/Read preference objects and the read_preference method> section
 below for more details.


### PR DESCRIPTION
It seems that there was never a global variable named
$MongoDB::Cursor::slave_ok