### PR TITLE
PERL-657 Documentation spelling fixes

### DIFF
--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -1901,7 +1901,7 @@ call C<get_collection> on a L<MongoDB::Database> object.
 
 =head2 Error handling
 
-Unless otherwise explictly documented, all methods throw exceptions if
+Unless otherwise explicitly documented, all methods throw exceptions if
 an error occurs.  The error types are documented in L<MongoDB::Error>.
 
 To catch and handle errors, the L<Try::Tiny> and L<Safe::Isa> modules
@@ -1965,7 +1965,7 @@ The C<get_collection> method is deprecated; it implied a 'subcollection'
 relationship that is purely notional.
 
 The C<ensure_index>, C<drop_indexes>, C<drop_index>, and C<get_index>
-methods are deprecated. The new L<MongoDB::IndexView> class is accessable
+methods are deprecated. The new L<MongoDB::IndexView> class is accessible
 through the C<indexes> method, and offer greater consistency in behavior
 across drivers.
 

--- a/lib/MongoDB/DataTypes.pod
+++ b/lib/MongoDB/DataTypes.pod
@@ -333,7 +333,7 @@ correctly in the database:
 
 "OID" stands for "Object ID", and is a unique id for identifying documents.
 OIDs are 12 bytes, which are guaranteed to be unique.  Their string form is
-a 24-character string of hexidecimal digits.
+a 24-character string of hexadecimal digits.
 
 To create a unique id:
 

--- a/lib/MongoDB/Database.pm
+++ b/lib/MongoDB/Database.pm
@@ -491,7 +491,7 @@ call C<get_database> on a L<MongoDB::MongoClient> object.
 
 =head2 Error handling
 
-Unless otherwise explictly documented, all methods throw exceptions if
+Unless otherwise explicitly documented, all methods throw exceptions if
 an error occurs.  The error types are documented in L<MongoDB::Error>.
 
 To catch and handle errors, the L<Try::Tiny> and L<Safe::Isa> modules

--- a/lib/MongoDB/Error.pm
+++ b/lib/MongoDB/Error.pm
@@ -307,11 +307,11 @@ __END__
 
 =head1 DESCRIPTION
 
-This class defines a heirarchy of exception objects.
+This class defines a hierarchy of exception objects.
 
 =head1 USAGE
 
-Unless otherwise explictly documented, all driver methods throw exceptions if
+Unless otherwise explicitly documented, all driver methods throw exceptions if
 an error occurs.
 
 To catch and handle errors, the L<Try::Tiny> and L<Safe::Isa> modules

--- a/lib/MongoDB/Examples.pod
+++ b/lib/MongoDB/Examples.pod
@@ -335,7 +335,7 @@ courses in which that student is enrolled:
 The C<$unwind> stage of the aggregation query "peels off" elements of the courses
 array one-by-one and places them in their own documents. After this phase completes,
 there is a separate document for each (course, student) pair. The C<$project> stage
-then throws out unecessary fields and keeps the ones we are interested in. It also
+then throws out unnecessary fields and keeps the ones we are interested in. It also
 pulls the student ID field out of its subdocument and creates a top-level field
 with the key C<student_id>. Last, we group by student ID, using C<$addToSet> in
 order to add the unique courses for each student to the C<courses> array.

--- a/lib/MongoDB/GridFS.pm
+++ b/lib/MongoDB/GridFS.pm
@@ -496,7 +496,7 @@ using one over the other is a matter of preference.
 
 =head2 Error handling
 
-Unless otherwise explictly documented, all methods throw exceptions if
+Unless otherwise explicitly documented, all methods throw exceptions if
 an error occurs.  The error types are documented in L<MongoDB::Error>.
 
 To catch and handle errors, the L<Try::Tiny> and L<Safe::Isa> modules

--- a/lib/MongoDB/GridFS/File.pm
+++ b/lib/MongoDB/GridFS/File.pm
@@ -170,7 +170,7 @@ your applications to L<MongoDB::GridFSBucket>.
 
 =head2 Error handling
 
-Unless otherwise explictly documented, all methods throw exceptions if
+Unless otherwise explicitly documented, all methods throw exceptions if
 an error occurs.  The error types are documented in L<MongoDB::Error>.
 
 To catch and handle errors, the L<Try::Tiny> and L<Safe::Isa> modules

--- a/lib/MongoDB/GridFSBucket.pm
+++ b/lib/MongoDB/GridFSBucket.pm
@@ -634,7 +634,7 @@ are two ways to go about uploading and downloading:
 
 =head2 Error handling
 
-Unless otherwise explictly documented, all methods throw exceptions if
+Unless otherwise explicitly documented, all methods throw exceptions if
 an error occurs.  The error types are documented in L<MongoDB::Error>.
 
 =head1 SEE ALSO

--- a/lib/MongoDB/OID.pm
+++ b/lib/MongoDB/OID.pm
@@ -38,7 +38,7 @@ use namespace::clean;
 =head2 value
 
 The OID value. A random value will be generated if none exists already.
-It is a 24-character hexidecimal string (12 bytes).
+It is a 24-character hexadecimal string (12 bytes).
 
 Its string representation is the 24-character string.
 
@@ -85,7 +85,7 @@ sub _new_oid {
 
     my $hex = $oid->to_string;
 
-Gets the value of this OID as a 24-digit hexidecimal string.
+Gets the value of this OID as a 24-digit hexadecimal string.
 
 =cut
 

--- a/lib/MongoDB/QueryResult.pm
+++ b/lib/MongoDB/QueryResult.pm
@@ -308,7 +308,7 @@ more efficient.
 
 =head2 Error handling
 
-Unless otherwise explictly documented, all methods throw exceptions if
+Unless otherwise explicitly documented, all methods throw exceptions if
 an error occurs.  The error types are documented in L<MongoDB::Error>.
 
 To catch and handle errors, the L<Try::Tiny> and L<Safe::Isa> modules

--- a/lib/MongoDB/Upgrading.pod
+++ b/lib/MongoDB/Upgrading.pod
@@ -576,7 +576,7 @@ triggering Perl memory bugs under threads.  Therefore, the v1.0.0 driver no
 longer support fetching directly from L<MongoDB::DBRef>; users will need to
 implement their own methods for dereferencing.
 
-Additonally, the C<db> attribute is now optional, consistent with the
+Additionally, the C<db> attribute is now optional, consistent with the
 specification for DBRefs.
 
 Also, all attributes (C<ref>, C<id> and C<db>) are now read-only,
@@ -613,7 +613,7 @@ new MongoDB driver API.
   have a Collection be a factory for collections.  Users who want nested
   namespaces should be explicit and create them off Database objects instead.
 * ensure_index, drop_indexes, drop_index, get_index — A new
-  L<MongoDB::IndexView> class is accessable through the C<indexes> method,
+  L<MongoDB::IndexView> class is accessible through the C<indexes> method,
   offering greater consistency in behavior across drivers.
 * validate — The return values have changed over different server versions,
   so this method is risky to use; it has more use as a one-off tool, which

--- a/lib/MongoDB/WriteConcern.pm
+++ b/lib/MongoDB/WriteConcern.pm
@@ -51,7 +51,7 @@ has w => (
 =attr wtimeout
 
 Specifies how long to wait for the write concern to be satisfied (in
-milliseonds).  Defaults to 1000.
+milliseconds).  Defaults to 1000.
 
 =cut
 


### PR DESCRIPTION
During the update of the Debian libmongodb-perl package a number of spelling typos were found in the documentation. This PR fixes the typos found.

Thank you to Gregor Herrmann ( @gregoa ) for providing the initial patch.