### PR TITLE
PERL-799: parse Logical session timeout from isMaster

### DIFF
--- a/lib/MongoDB/_Server.pm
+++ b/lib/MongoDB/_Server.pm
@@ -251,6 +251,17 @@ sub _build_is_writable {
     return !! grep { $type eq $_ } qw/Standalone RSPrimary Mongos/;
 }
 
+has logical_session_timeout_minutes => (
+  is => 'lazy',
+  isa => NonNegNum,
+  builder => "_build_logical_session_timeout_minutes",
+);
+
+sub _build_logical_session_timeout_minutes {
+    my ( $self ) = @_;
+   return $self->is_master->{localLogicalSessionTimeoutMinutes} || 0;
+}
+
 sub updated_since {
     my ( $self, $time ) = @_;
     return( ($self->last_update_time - $time) > 0 );

--- a/lib/MongoDB/_Server.pm
+++ b/lib/MongoDB/_Server.pm
@@ -252,25 +252,19 @@ sub _build_is_writable {
     return !! grep { $type eq $_ } qw/Standalone RSPrimary Mongos/;
 }
 
-# logicalSessionTimeoutMinutes can be not set by a client
-
-has defined_ls_timeout_minutes => (
+has is_data_bearing => (
     is => 'lazy',
     isa => Bool,
-    builder => "_build_defined_ls_timeout_minutes",
+    builder => "_build_is_data_bearing",
 );
 
-sub _build_defined_ls_timeout_minutes {
+sub _build_is_data_bearing {
     my ( $self ) = @_;
-
-    if ( exists $self->is_master->{logicalSessionTimeoutMinutes}
-      || $self->type eq 'RSPrimary'
-      || $self->type eq 'Mongos' ) {
-        return 1;
-    }
-    return;
+    my $type = $self->type;
+    return !! grep { $type eq $_ } qw/Standalone RSPrimary RSSecondary Mongos/;
 }
 
+# logicalSessionTimeoutMinutes can be not set by a client
 has logical_session_timeout_minutes => (
     is => 'lazy',
     isa => Maybe [NonNegNum],

--- a/lib/MongoDB/_Topology.pm
+++ b/lib/MongoDB/_Topology.pm
@@ -569,6 +569,7 @@ sub _update_ls_timeout_minutes {
           ? $_->logical_session_timeout_minutes
           : -1
     } @data_bearing_servers;
+    # min will return undef if the array is empty
     if ( defined $timeout && $timeout < 0 ) {
         $timeout = undef;
     }

--- a/t/data/SDAM/rs/compatible.json
+++ b/t/data/SDAM/rs/compatible.json
@@ -1,0 +1,55 @@
+{
+  "description": "Replica set member with large maxWireVersion",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 1000
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/compatible.yml
+++ b/t/data/SDAM/rs/compatible.yml
@@ -1,0 +1,41 @@
+description: "Replica set member with large maxWireVersion"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 1000
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs",
+            logicalSessionTimeoutMinutes: null,
+            compatible: true
+        }
+    }
+]

--- a/t/data/SDAM/rs/discover_arbiters.json
+++ b/t/data/SDAM/rs/discover_arbiters.json
@@ -1,38 +1,41 @@
 {
-    "description": "Discover arbiters", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "arbiters": [
-                            "b:27017"
-                        ], 
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Discover arbiters",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "arbiters": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/discover_arbiters.yml
+++ b/t/data/SDAM/rs/discover_arbiters.yml
@@ -13,7 +13,9 @@ phases: [
                     ismaster: true,
                     hosts: ["a:27017"],
                     arbiters: ["b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -33,8 +35,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/discover_passives.json
+++ b/t/data/SDAM/rs/discover_passives.json
@@ -1,72 +1,78 @@
 {
-    "description": "Discover passives", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "passives": [
-                            "b:27017"
-                        ], 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "passive": true, 
-                        "passives": [
-                            "b:27017"
-                        ], 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Discover passives",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "passives": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "passive": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "passives": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/discover_passives.yml
+++ b/t/data/SDAM/rs/discover_passives.yml
@@ -13,7 +13,9 @@ phases: [
                     ismaster: true,
                     hosts: ["a:27017"],
                     passives: ["b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -33,8 +35,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -49,7 +51,9 @@ phases: [
                     passive: true,
                     hosts: ["a:27017"],
                     passives: ["b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -69,8 +73,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/discover_primary.json
+++ b/t/data/SDAM/rs/discover_primary.json
@@ -1,36 +1,39 @@
 {
-    "description": "Replica set discovery from primary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Replica set discovery from primary",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/discover_primary.yml
+++ b/t/data/SDAM/rs/discover_primary.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -32,8 +34,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/discover_secondary.json
+++ b/t/data/SDAM/rs/discover_secondary.json
@@ -1,37 +1,40 @@
 {
-    "description": "Replica set discovery from secondary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://b/?replicaSet=rs"
+  "description": "Replica set discovery from secondary",
+  "uri": "mongodb://b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/discover_secondary.yml
+++ b/t/data/SDAM/rs/discover_secondary.yml
@@ -13,7 +13,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -33,8 +35,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/discovery.json
+++ b/t/data/SDAM/rs/discovery.json
@@ -1,163 +1,175 @@
 {
-    "description": "Replica set discovery", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "c:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }, 
-                    "c:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "d:27017": {
-                        "setName": null, 
-                        "type": "PossiblePrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "b:27017", 
-                            "c:27017", 
-                            "d:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "primary": "d:27017", 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }, 
-                    "c:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "d:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "e:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "d:27017", 
-                    {
-                        "hosts": [
-                            "b:27017", 
-                            "c:27017", 
-                            "d:27017", 
-                            "e:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }, 
-                    "c:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }, 
-                    "d:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "e:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "c:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Replica set discovery",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "primary": "d:27017",
+            "hosts": [
+              "b:27017",
+              "c:27017",
+              "d:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "PossiblePrimary",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "d:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "e:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "e:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/discovery.yml
+++ b/t/data/SDAM/rs/discovery.yml
@@ -14,7 +14,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017", "c:27017"]
+                    hosts: ["a:27017", "b:27017", "c:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -40,8 +42,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -57,7 +59,9 @@ phases: [
                     secondary: true,
                     setName: "rs",
                     primary: "d:27017",
-                    hosts: ["b:27017", "c:27017", "d:27017"]
+                    hosts: ["b:27017", "c:27017", "d:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -89,8 +93,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -104,7 +108,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["b:27017", "c:27017", "d:27017", "e:27017"]
+                    hosts: ["b:27017", "c:27017", "d:27017", "e:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -137,8 +143,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -153,7 +159,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017", "c:27017"]
+                    hosts: ["a:27017", "b:27017", "c:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -187,8 +195,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/equal_electionids.json
+++ b/t/data/SDAM/rs/equal_electionids.json
@@ -1,62 +1,67 @@
 {
-    "description": "New primary with equal electionId", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "setVersion": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "New primary with equal electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "setVersion": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/equal_electionids.yml
+++ b/t/data/SDAM/rs/equal_electionids.yml
@@ -13,7 +13,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }],
             ["b:27017", {
                 ok: 1,
@@ -21,7 +23,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -42,6 +46,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/ghost_discovered.json
+++ b/t/data/SDAM/rs/ghost_discovered.json
@@ -1,32 +1,35 @@
 {
-    "description": "Ghost discovered", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "RSGhost"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "ismaster": false, 
-                        "isreplicaset": true, 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "Ghost discovered",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "isreplicaset": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "RSGhost",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/ghost_discovered.yml
+++ b/t/data/SDAM/rs/ghost_discovered.yml
@@ -11,7 +11,9 @@ phases: [
 
                     ok: 1,
                     ismaster: false,
-                    isreplicaset: true
+                    isreplicaset: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -31,8 +33,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/hosts_differ_from_seeds.json
+++ b/t/data/SDAM/rs/hosts_differ_from_seeds.json
@@ -1,31 +1,34 @@
 {
-    "description": "Host list differs from seeds", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Host list differs from seeds",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/hosts_differ_from_seeds.yml
+++ b/t/data/SDAM/rs/hosts_differ_from_seeds.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["b:27017"]
+                    hosts: ["b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -26,8 +28,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/ls_timeout.json
+++ b/t/data/SDAM/rs/ls_timeout.json
@@ -1,0 +1,273 @@
+{
+  "description": "Parse logicalSessionTimeoutMinutes from replica set",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "logicalSessionTimeoutMinutes": 3,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "Unknown"
+          },
+          "e:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "d:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "isreplicaset": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "e:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "arbiterOnly": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "logicalSessionTimeoutMinutes": 2,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 2,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "setName": "rs",
+            "hidden": true,
+            "logicalSessionTimeoutMinutes": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 2,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "logicalSessionTimeoutMinutes": null,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/ls_timeout.yml
+++ b/t/data/SDAM/rs/ls_timeout.yml
@@ -1,0 +1,243 @@
+description: "Parse logicalSessionTimeoutMinutes from replica set"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+    # An RSPrimary responds with a non-null logicalSessionTimeoutMinutes
+    {
+        responses: [
+             ["a:27017", {
+                ok: 1,
+                ismaster: true,
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
+                setName: "rs",
+                logicalSessionTimeoutMinutes: 3,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "Unknown",
+                },
+                "e:27017": {
+                    type: "Unknown",
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 3,
+            setName: "rs",
+        }
+    },
+    # An RSGhost responds without a logicalSessionTimeoutMinutes
+    {
+        responses: [
+            ["d:27017", {
+                ok: 1,
+                ismaster: false,
+                isreplicaset: true,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "Unknown",
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 3,
+            setName: "rs",
+        }
+    },
+    # An RSArbiter responds without a logicalSessionTimeoutMinutes
+    {
+        responses: [
+           ["e:27017", {
+                ok: 1,
+                ismaster: false,
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
+                setName: "rs",
+                arbiterOnly: true,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 3,
+            setName: "rs",
+        }
+    },
+    # An RSSecondary responds with a lower logicalSessionTimeoutMinutes
+    {
+        responses: [
+            ["b:27017", {
+                ok: 1,
+                ismaster: false,
+                secondary: true,
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
+                setName: "rs",
+                logicalSessionTimeoutMinutes: 2,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 2,
+            setName: "rs",
+        }
+    },
+    # An RSOther responds with an even lower logicalSessionTimeoutMinutes, which is ignored
+    {
+        responses: [
+            ["c:27017", {
+                ok: 1,
+                ismaster: false,
+                setName: "rs",
+                hidden: true,
+                logicalSessionTimeoutMinutes: 1,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+                "c:27017": {
+                    type: "RSOther",
+                    setName: "rs"
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
+              }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 2,
+            setName: "rs",
+        }
+    },
+    # Now the RSSecondary responds with no logicalSessionTimeoutMinutes
+    {
+        responses: [
+            ["b:27017", {
+                ok: 1,
+                ismaster: false,
+                secondary: true,
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
+                setName: "rs",
+                logicalSessionTimeoutMinutes: null,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }]
+        ],
+
+        # Sessions aren't supported now
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+                "c:27017": {
+                    type: "RSOther",
+                    setName: "rs"
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    }
+]

--- a/t/data/SDAM/rs/member_reconfig.json
+++ b/t/data/SDAM/rs/member_reconfig.json
@@ -1,61 +1,67 @@
 {
-    "description": "Member removed by reconfig", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "Member removed by reconfig",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/member_reconfig.yml
+++ b/t/data/SDAM/rs/member_reconfig.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -32,8 +34,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -46,7 +48,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017"]
+                    hosts: ["a:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -60,8 +64,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/member_standalone.json
+++ b/t/data/SDAM/rs/member_standalone.json
@@ -1,52 +1,58 @@
 {
-    "description": "Member brought up as standalone", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Unknown"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "ismaster": true, 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b"
+  "description": "Member brought up as standalone",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "Unknown",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/member_standalone.yml
+++ b/t/data/SDAM/rs/member_standalone.yml
@@ -10,7 +10,9 @@ phases: [
                 ["b:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -24,8 +26,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Unknown",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     },
@@ -38,7 +40,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017"]
+                    hosts: ["a:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -52,8 +56,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/new_primary.json
+++ b/t/data/SDAM/rs/new_primary.json
@@ -1,66 +1,72 @@
 {
-    "description": "New primary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "New primary",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/new_primary.yml
+++ b/t/data/SDAM/rs/new_primary.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -32,8 +34,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -46,7 +48,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -66,8 +70,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/new_primary_new_electionid.json
+++ b/t/data/SDAM/rs/new_primary_new_electionid.json
@@ -1,123 +1,132 @@
 {
-    "description": "New primary with greater setVersion and electionId", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "New primary with greater setVersion and electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/new_primary_new_electionid.yml
+++ b/t/data/SDAM/rs/new_primary_new_electionid.yml
@@ -13,7 +13,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -32,6 +34,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -45,7 +48,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000002"}
+                electionId: {"$oid": "000000000000000000000002"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -64,6 +69,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -77,7 +83,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -95,6 +103,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/new_primary_new_setversion.json
+++ b/t/data/SDAM/rs/new_primary_new_setversion.json
@@ -1,123 +1,132 @@
 {
-    "description": "New primary with greater setVersion", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "New primary with greater setVersion",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/new_primary_new_setversion.yml
+++ b/t/data/SDAM/rs/new_primary_new_setversion.yml
@@ -13,7 +13,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -32,6 +34,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -45,7 +48,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 2,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -64,6 +69,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -77,7 +83,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -91,10 +99,11 @@ phases: [
                     type: "RSPrimary",
                     setName: "rs",
                     setVersion: 2,
-                    electionId: {"$oid": "000000000000000000000002"}
+                    electionId: {"$oid": "000000000000000000000001"}
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/new_primary_wrong_set_name.json
+++ b/t/data/SDAM/rs/new_primary_wrong_set_name.json
@@ -1,61 +1,67 @@
 {
-    "description": "New primary with wrong setName", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "New primary with wrong setName",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/new_primary_wrong_set_name.yml
+++ b/t/data/SDAM/rs/new_primary_wrong_set_name.yml
@@ -13,7 +13,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017", "b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -33,8 +35,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -49,7 +51,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -63,8 +67,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/non_rs_member.json
+++ b/t/data/SDAM/rs/non_rs_member.json
@@ -1,26 +1,29 @@
 {
-    "description": "Non replicaSet member responds", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "Non replicaSet member responds",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/non_rs_member.yml
+++ b/t/data/SDAM/rs/non_rs_member.yml
@@ -8,8 +8,9 @@ phases: [
         responses: [
 
                 ["b:27017", {
-
-                    ok: 1
+                    ok: 1,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -23,8 +24,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/normalize_case.json
+++ b/t/data/SDAM/rs/normalize_case.json
@@ -1,45 +1,48 @@
 {
-    "description": "Replica set case normalization", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "c:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "arbiters": [
-                            "C:27017"
-                        ], 
-                        "hosts": [
-                            "A:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "passives": [
-                            "B:27017"
-                        ], 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://A/?replicaSet=rs"
+  "description": "Replica set case normalization",
+  "uri": "mongodb://A/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "A:27017"
+            ],
+            "passives": [
+              "B:27017"
+            ],
+            "arbiters": [
+              "C:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/normalize_case.yml
+++ b/t/data/SDAM/rs/normalize_case.yml
@@ -14,7 +14,9 @@ phases: [
                     setName: "rs",
                     hosts: ["A:27017"],
                     passives: ["B:27017"],
-                    arbiters: ["C:27017"]
+                    arbiters: ["C:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -41,8 +43,8 @@ phases: [
                 }
 
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/null_election_id.json
+++ b/t/data/SDAM/rs/null_election_id.json
@@ -1,173 +1,186 @@
 {
-    "description": "Primaries with and without electionIds", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "c:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "c:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "c:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "c:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "c:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Primaries with and without electionIds",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "setVersion": 1,
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "setVersion": 1,
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/null_election_id.yml
+++ b/t/data/SDAM/rs/null_election_id.yml
@@ -12,7 +12,9 @@ phases: [
                 ismaster: true,
                 hosts: ["a:27017", "b:27017", "c:27017"],
                 setVersion: 1,
-                setName: "rs"
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -36,6 +38,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -49,7 +52,9 @@ phases: [
                 hosts: ["a:27017", "b:27017", "c:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000002"}
+                electionId: {"$oid": "000000000000000000000002"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -73,6 +78,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -85,7 +91,9 @@ phases: [
                 ismaster: true,
                 hosts: ["a:27017", "b:27017", "c:27017"],
                 setVersion: 1,
-                setName: "rs"
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -108,6 +116,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -122,7 +131,9 @@ phases: [
                 hosts: ["a:27017", "b:27017", "c:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -131,6 +142,7 @@ phases: [
                 "a:27017": {
                     type: "RSPrimary",
                     setName: "rs",
+                    setVersion: 1,
                     electionId:
                 },
                 "b:27017": {
@@ -145,6 +157,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/primary_becomes_standalone.json
+++ b/t/data/SDAM/rs/primary_becomes_standalone.json
@@ -1,46 +1,52 @@
 {
-    "description": "Primary becomes standalone", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {}, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Primary becomes standalone",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_becomes_standalone.yml
+++ b/t/data/SDAM/rs/primary_becomes_standalone.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -26,26 +28,26 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
 
     {
         responses: [
-
                 ["a:27017", {
-
-                    ok: 1
+                    ok: 1,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
         outcome: {
 
             servers: {},
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/primary_changes_set_name.json
+++ b/t/data/SDAM/rs/primary_changes_set_name.json
@@ -1,51 +1,57 @@
 {
-    "description": "Primary changes setName", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {}, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Primary changes setName",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_changes_set_name.yml
+++ b/t/data/SDAM/rs/primary_changes_set_name.yml
@@ -13,7 +13,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -27,8 +29,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -42,15 +44,17 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
         outcome: {
 
             servers: {},
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/primary_disconnect.json
+++ b/t/data/SDAM/rs/primary_disconnect.json
@@ -1,49 +1,53 @@
 {
-    "description": "Disconnected from primary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {}
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Disconnected from primary",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_disconnect.yml
+++ b/t/data/SDAM/rs/primary_disconnect.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -26,8 +28,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -48,8 +50,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/primary_disconnect_electionid.json
+++ b/t/data/SDAM/rs/primary_disconnect_electionid.json
@@ -1,196 +1,210 @@
 {
-    "description": "Disconnected from primary, reject primary with stale electionId", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {}
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000003"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000003"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Disconnected from primary, reject primary with stale electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000003"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000003"
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000003"
+            }
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_disconnect_electionid.yml
+++ b/t/data/SDAM/rs/primary_disconnect_electionid.yml
@@ -13,7 +13,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }],
             ["b:27017", {
                 ok: 1,
@@ -21,7 +23,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000002"}
+                electionId: {"$oid": "000000000000000000000002"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -40,6 +44,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -63,6 +68,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -76,7 +82,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -93,6 +101,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -106,7 +115,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000003"}
+                electionId: {"$oid": "000000000000000000000003"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -124,6 +135,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -137,7 +149,8 @@ phases: [
                 secondary: true,
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
-                setVersion: 2
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -146,7 +159,7 @@ phases: [
                     type: "RSPrimary",
                     setName: "rs",
                     setVersion: 1,
-                    electionId: {"$oid": "000000000000000000000002"}
+                    electionId: {"$oid": "000000000000000000000003"}
                 },
                 "b:27017": {
                     type: "RSSecondary",
@@ -154,6 +167,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/primary_disconnect_setversion.json
+++ b/t/data/SDAM/rs/primary_disconnect_setversion.json
@@ -1,196 +1,210 @@
 {
-    "description": "Disconnected from primary, reject primary with stale setVersion", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {}
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Disconnected from primary, reject primary with stale setVersion",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            }
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_disconnect_setversion.yml
+++ b/t/data/SDAM/rs/primary_disconnect_setversion.yml
@@ -13,7 +13,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }],
             ["b:27017", {
                 ok: 1,
@@ -21,7 +23,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 2,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -40,6 +44,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -63,6 +68,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -76,7 +82,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -93,6 +101,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -106,7 +115,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 2,
-                electionId: {"$oid": "000000000000000000000002"}
+                electionId: {"$oid": "000000000000000000000002"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -124,6 +135,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -137,7 +149,8 @@ phases: [
                 secondary: true,
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
-                setVersion: 2
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -154,6 +167,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/primary_hint_from_secondary_with_mismatched_me.json
+++ b/t/data/SDAM/rs/primary_hint_from_secondary_with_mismatched_me.json
@@ -1,0 +1,66 @@
+{
+  "description": "Secondary with mismatched 'me' tells us who the primary is",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "me": "c:27017",
+            "hosts": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "primary": "b:27017",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "PossiblePrimary",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "me": "b:27017",
+            "hosts": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/primary_hint_from_secondary_with_mismatched_me.yml
+++ b/t/data/SDAM/rs/primary_hint_from_secondary_with_mismatched_me.yml
@@ -1,0 +1,62 @@
+description: "Secondary with mismatched 'me' tells us who the primary is"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    # A is a secondary with mismatched "me". Remove A, add PossiblePrimary B.
+    {
+        responses: [
+            ["a:27017", {
+                ok: 1,
+                ismaster: false,
+                secondary: true,
+                me: "c:27017",
+                hosts: ["b:27017"],
+                setName: "rs",
+                primary: "b:27017",
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "b:27017": {
+                    type: "PossiblePrimary",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs",
+        }
+    },
+
+    # Discover B is primary.
+    {
+        responses: [
+            ["b:27017", {
+                ok: 1,
+                ismaster: true,
+                me: "b:27017",
+                hosts: ["b:27017"],
+                setName: "rs",
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }]
+        ],
+
+        outcome: {
+            servers: {
+                "b:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/t/data/SDAM/rs/primary_mismatched_me.json
+++ b/t/data/SDAM/rs/primary_mismatched_me.json
@@ -1,37 +1,40 @@
 {
-    "description": "Primary mismatched me", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "localhost:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "me": "a:27017", 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://localhost:27017/?replicaSet=rs"
+  "description": "Primary mismatched me",
+  "phases": [
+    {
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "setName": null,
+            "type": "Unknown"
+          },
+          "b:27017": {
+            "setName": null,
+            "type": "Unknown"
+          }
+        },
+        "setName": "rs",
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null
+      },
+      "responses": [
+        [
+          "localhost:27017",
+          {
+            "me": "a:27017",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "ismaster": true,
+            "ok": 1,
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ]
+    }
+  ],
+  "uri": "mongodb://localhost:27017/?replicaSet=rs"
 }

--- a/t/data/SDAM/rs/primary_mismatched_me.yml
+++ b/t/data/SDAM/rs/primary_mismatched_me.yml
@@ -1,37 +1,26 @@
-{
-    "description": "Primary mismatched me",
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null,
-                        "type": "Unknown"
-                    },
-                    "b:27017": {
-                        "setName": null,
-                        "type": "Unknown"
-                    }
-                },
-                "setName": "rs",
-                "topologyType": "ReplicaSetNoPrimary"
-            },
-            "responses": [
-                [
-                    "localhost:27017",
-                     {
-                         "me": "a:27017",
-                         "hosts": [
-                             "a:27017",
-                             "b:27017"
-                         ],
-                         "ismaster": true,
-                         "ok": 1,
-                         "setName": "rs"
-                     }
-                ]
-            ]
-        }
-    ],
-    "uri": "mongodb://localhost:27017/?replicaSet=rs"
-}
+description: Primary mismatched me
+phases:
+  - outcome:
+      servers:
+        'a:27017':
+          setName: null
+          type: Unknown
+        'b:27017':
+          setName: null
+          type: Unknown
+      setName: rs
+      topologyType: ReplicaSetNoPrimary
+      logicalSessionTimeoutMinutes: null
+    responses:
+      - - 'localhost:27017'
+        - me: 'a:27017'
+          hosts:
+            - 'a:27017'
+            - 'b:27017'
+          ismaster: true
+          ok: 1
+          setName: rs
+          minWireVersion: 0
+          maxWireVersion: 6
+uri: 'mongodb://localhost:27017/?replicaSet=rs'
+

--- a/t/data/SDAM/rs/primary_reports_new_member.json
+++ b/t/data/SDAM/rs/primary_reports_new_member.json
@@ -1,0 +1,151 @@
+{
+  "description": "Primary reports a new member",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "primary": "b:27017",
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/primary_reports_new_member.yml
+++ b/t/data/SDAM/rs/primary_reports_new_member.yml
@@ -1,0 +1,171 @@
+description: "Primary reports a new member"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    # At first, a is a secondary.
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    # b is the primary.
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    # Admin adds a secondary member c.
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017", "c:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            # c is new.
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    # c becomes secondary.
+    {
+        responses: [
+
+                ["c:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    primary: "b:27017",
+                    hosts: ["a:27017", "b:27017", "c:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            # c is a secondary.
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/t/data/SDAM/rs/primary_to_no_primary_mismatched_me.json
+++ b/t/data/SDAM/rs/primary_to_no_primary_mismatched_me.json
@@ -1,68 +1,74 @@
 {
-    "description": "Primary to no primary with mismatched me", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "me": "a:27017", 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "c:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "d:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "c:27017", 
-                            "d:27017"
-                        ], 
-                        "ismaster": true, 
-                        "me": "c:27017", 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Primary to no primary with mismatched me",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "me": "a:27017",
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "me": "c:27017",
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_to_no_primary_mismatched_me.yml
+++ b/t/data/SDAM/rs/primary_to_no_primary_mismatched_me.yml
@@ -13,7 +13,9 @@ phases: [
                     ismaster: true,
                     hosts: ["a:27017", "b:27017"],
                     me: "a:27017",
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -33,8 +35,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -47,7 +49,9 @@ phases: [
                     ismaster: true,
                     hosts: ["c:27017", "d:27017"],
                     me : "c:27017",
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -67,8 +71,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/primary_wrong_set_name.json
+++ b/t/data/SDAM/rs/primary_wrong_set_name.json
@@ -1,26 +1,29 @@
 {
-    "description": "Primary wrong setName", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {}, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Primary wrong setName",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/primary_wrong_set_name.yml
+++ b/t/data/SDAM/rs/primary_wrong_set_name.yml
@@ -12,15 +12,17 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
         outcome: {
 
             servers: {},
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/response_from_removed.json
+++ b/t/data/SDAM/rs/response_from_removed.json
@@ -1,58 +1,64 @@
 {
-    "description": "Response from removed server", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "Response from removed server",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/response_from_removed.yml
+++ b/t/data/SDAM/rs/response_from_removed.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017"]
+                    hosts: ["a:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -26,8 +28,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -41,7 +43,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -55,8 +59,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/rsother_discovered.json
+++ b/t/data/SDAM/rs/rsother_discovered.json
@@ -1,59 +1,64 @@
 {
-    "description": "RSOther discovered", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSOther"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSOther"
-                    }, 
-                    "c:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "d:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hidden": true, 
-                        "hosts": [
-                            "c:27017", 
-                            "d:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "c:27017", 
-                            "d:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": false, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "RSOther discovered",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": false,
+            "hosts": [
+              "c:27017",
+              "d:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "d:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/rsother_discovered.yml
+++ b/t/data/SDAM/rs/rsother_discovered.yml
@@ -14,7 +14,9 @@ phases: [
                     secondary: true,
                     hidden: true,
                     hosts: ["c:27017", "d:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
                 ["b:27017", {
 
@@ -22,7 +24,9 @@ phases: [
                     ismaster: false,
                     secondary: false,
                     hosts: ["c:27017", "d:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -54,8 +58,8 @@ phases: [
                     setName: 
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/sec_not_auth.json
+++ b/t/data/SDAM/rs/sec_not_auth.json
@@ -1,49 +1,54 @@
 {
-    "description": "Secondary's host list is not authoritative", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Secondary's host list is not authoritative",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "b:27017",
+              "c:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/sec_not_auth.yml
+++ b/t/data/SDAM/rs/sec_not_auth.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["b:27017", {
@@ -21,7 +23,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["b:27017", "c:27017"]
+                    hosts: ["b:27017", "c:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -41,8 +45,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/secondary_mismatched_me.json
+++ b/t/data/SDAM/rs/secondary_mismatched_me.json
@@ -1,37 +1,40 @@
 {
-    "description": "Secondary mismatched me", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "localhost:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": false, 
-                        "me": "a:27017", 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://localhost:27017/?replicaSet=rs"
+  "description": "Secondary mismatched me",
+  "phases": [
+    {
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "setName": null,
+            "type": "Unknown"
+          },
+          "b:27017": {
+            "setName": null,
+            "type": "Unknown"
+          }
+        },
+        "setName": "rs",
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null
+      },
+      "responses": [
+        [
+          "localhost:27017",
+          {
+            "me": "a:27017",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "ismaster": false,
+            "ok": 1,
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ]
+    }
+  ],
+  "uri": "mongodb://localhost:27017/?replicaSet=rs"
 }

--- a/t/data/SDAM/rs/secondary_mismatched_me.yml
+++ b/t/data/SDAM/rs/secondary_mismatched_me.yml
@@ -1,37 +1,26 @@
-{
-    "description": "Secondary mismatched me",
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null,
-                        "type": "Unknown"
-                    },
-                    "b:27017": {
-                        "setName": null,
-                        "type": "Unknown"
-                    }
-                },
-                "setName": "rs",
-                "topologyType": "ReplicaSetNoPrimary"
-            },
-            "responses": [
-                [
-                    "localhost:27017",
-                     {
-                         "me": "a:27017",
-                         "hosts": [
-                             "a:27017",
-                             "b:27017"
-                         ],
-                         "ismaster": false,
-                         "ok": 1,
-                         "setName": "rs"
-                     }
-                ]
-            ]
-        }
-    ],
-    "uri": "mongodb://localhost:27017/?replicaSet=rs"
-}
+description: Secondary mismatched me
+phases:
+  - outcome:
+      servers:
+        'a:27017':
+          setName: null
+          type: Unknown
+        'b:27017':
+          setName: null
+          type: Unknown
+      setName: rs
+      topologyType: ReplicaSetNoPrimary
+      logicalSessionTimeoutMinutes: null
+    responses:
+      - - 'localhost:27017'
+        - me: 'a:27017'
+          hosts:
+            - 'a:27017'
+            - 'b:27017'
+          ismaster: false
+          ok: 1
+          setName: rs
+          minWireVersion: 0
+          maxWireVersion: 6
+uri: 'mongodb://localhost:27017/?replicaSet=rs'
+

--- a/t/data/SDAM/rs/secondary_wrong_set_name.json
+++ b/t/data/SDAM/rs/secondary_wrong_set_name.json
@@ -1,27 +1,30 @@
 {
-    "description": "Secondary wrong setName", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {}, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Secondary wrong setName",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/secondary_wrong_set_name.yml
+++ b/t/data/SDAM/rs/secondary_wrong_set_name.yml
@@ -13,15 +13,17 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     hosts: ["a:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
         outcome: {
 
             servers: {},
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/secondary_wrong_set_name_with_primary.json
+++ b/t/data/SDAM/rs/secondary_wrong_set_name_with_primary.json
@@ -1,63 +1,69 @@
 {
-    "description": "Secondary wrong setName with primary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "Secondary wrong setName with primary",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/secondary_wrong_set_name_with_primary.yml
+++ b/t/data/SDAM/rs/secondary_wrong_set_name_with_primary.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017", "b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -32,8 +34,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -47,7 +49,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     hosts: ["a:27017", "b:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -61,8 +65,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/setversion_without_electionid.json
+++ b/t/data/SDAM/rs/setversion_without_electionid.json
@@ -1,74 +1,80 @@
 {
-    "description": "setVersion is ignored if there is no electionId", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "setVersion is ignored if there is no electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/setversion_without_electionid.yml
+++ b/t/data/SDAM/rs/setversion_without_electionid.yml
@@ -12,7 +12,9 @@ phases: [
                 ismaster: true,
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
-                setVersion: 2
+                setVersion: 2,
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -31,6 +33,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -44,7 +47,9 @@ phases: [
                 ismaster: true,
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
-                setVersion: 1
+                setVersion: 1,
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -63,6 +68,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/stepdown_change_set_name.json
+++ b/t/data/SDAM/rs/stepdown_change_set_name.json
@@ -1,52 +1,58 @@
 {
-    "description": "Primary becomes a secondary with wrong setName", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {}, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Primary becomes a secondary with wrong setName",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/stepdown_change_set_name.yml
+++ b/t/data/SDAM/rs/stepdown_change_set_name.yml
@@ -13,7 +13,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["a:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -27,8 +29,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     },
@@ -44,15 +46,17 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     hosts: ["a:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
         outcome: {
 
             servers: {},
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/too_new.json
+++ b/t/data/SDAM/rs/too_new.json
@@ -1,0 +1,55 @@
+{
+  "description": "Replica set member with large minWireVersion",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 999,
+            "maxWireVersion": 1000
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/too_new.yml
+++ b/t/data/SDAM/rs/too_new.yml
@@ -1,0 +1,41 @@
+description: "Replica set member with large minWireVersion"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs",
+            logicalSessionTimeoutMinutes: null,
+            compatible: false
+        }
+    }
+]

--- a/t/data/SDAM/rs/too_old.json
+++ b/t/data/SDAM/rs/too_old.json
@@ -1,0 +1,53 @@
+{
+  "description": "Replica set member with default maxWireVersion of 0",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ]
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/too_old.yml
+++ b/t/data/SDAM/rs/too_old.yml
@@ -1,0 +1,39 @@
+description: "Replica set member with default maxWireVersion of 0"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"]
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs",
+            logicalSessionTimeoutMinutes: null,
+            compatible: false
+        }
+    }
+]

--- a/t/data/SDAM/rs/unexpected_mongos.json
+++ b/t/data/SDAM/rs/unexpected_mongos.json
@@ -1,23 +1,26 @@
 {
-    "description": "Unexpected mongos", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {}, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://b/?replicaSet=rs"
+  "description": "Unexpected mongos",
+  "uri": "mongodb://b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/unexpected_mongos.yml
+++ b/t/data/SDAM/rs/unexpected_mongos.yml
@@ -11,15 +11,17 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
         outcome: {
 
             servers: {},
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/rs/use_setversion_without_electionid.json
+++ b/t/data/SDAM/rs/use_setversion_without_electionid.json
@@ -1,114 +1,123 @@
 {
-    "description": "Record max setVersion, even from primary without electionId", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "setName": "rs", 
-                        "setVersion": 1, 
-                        "type": "RSPrimary"
-                    }, 
-                    "b:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000001"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 2
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "electionId": null, 
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": "rs", 
-                        "setVersion": 2, 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetWithPrimary"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "electionId": {
-                            "$oid": "000000000000000000000002"
-                        }, 
-                        "hosts": [
-                            "a:27017", 
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs", 
-                        "setVersion": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a/?replicaSet=rs"
+  "description": "Record max setVersion, even from primary without electionId",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 2,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "setVersion": 1,
+            "electionId": {
+              "$oid": "000000000000000000000002"
+            },
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null,
+            "electionId": null
+          },
+          "b:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "setVersion": 2
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/use_setversion_without_electionid.yml
+++ b/t/data/SDAM/rs/use_setversion_without_electionid.yml
@@ -13,7 +13,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000001"}
+                electionId: {"$oid": "000000000000000000000001"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -32,6 +34,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -44,7 +47,9 @@ phases: [
                 ismaster: true,
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
-                setVersion: 2
+                setVersion: 2,
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
 
@@ -62,6 +67,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     },
@@ -76,7 +82,9 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 setVersion: 1,
-                electionId: {"$oid": "000000000000000000000002"}
+                electionId: {"$oid": "000000000000000000000002"},
+                minWireVersion: 0,
+                maxWireVersion: 6
             }]
         ],
         outcome: {
@@ -93,6 +101,7 @@ phases: [
                 }
             },
             topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs",
         }
     }

--- a/t/data/SDAM/rs/wrong_set_name.json
+++ b/t/data/SDAM/rs/wrong_set_name.json
@@ -1,33 +1,36 @@
 {
-    "description": "Wrong setName", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": "rs", 
-                "topologyType": "ReplicaSetNoPrimary"
-            }, 
-            "responses": [
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "b:27017", 
-                            "c:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "wrong"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b/?replicaSet=rs"
+  "description": "Wrong setName",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "b:27017",
+              "c:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/rs/wrong_set_name.yml
+++ b/t/data/SDAM/rs/wrong_set_name.yml
@@ -13,7 +13,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     hosts: ["b:27017", "c:27017"],
-                    setName: "wrong"
+                    setName: "wrong",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -27,8 +29,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
             setName: "rs"
         }
     }

--- a/t/data/SDAM/sharded/compatible.json
+++ b/t/data/SDAM/sharded/compatible.json
@@ -1,0 +1,46 @@
+{
+  "description": "Multiple mongoses with large maxWireVersion",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 1000
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/sharded/compatible.yml
+++ b/t/data/SDAM/sharded/compatible.yml
@@ -1,0 +1,38 @@
+description: "Multiple mongoses with large maxWireVersion"
+uri: "mongodb://a,b"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 1000
+                }],
+                ["b:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Mongos",
+                    setName:
+                },
+                "b:27017": {
+                    type: "Mongos",
+                    setName:
+                }
+            },
+            topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: true
+        }
+    }
+]

--- a/t/data/SDAM/sharded/ls_timeout_mongos.json
+++ b/t/data/SDAM/sharded/ls_timeout_mongos.json
@@ -1,0 +1,87 @@
+{
+  "description": "Parse logicalSessionTimeoutMinutes from mongoses",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "logicalSessionTimeoutMinutes": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "logicalSessionTimeoutMinutes": 2,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": 1,
+        "setName": null
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "logicalSessionTimeoutMinutes": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/sharded/ls_timeout_mongos.yml
+++ b/t/data/SDAM/sharded/ls_timeout_mongos.yml
@@ -1,0 +1,97 @@
+description: "Parse logicalSessionTimeoutMinutes from mongoses"
+
+uri: "mongodb://a,b"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    logicalSessionTimeoutMinutes: 1,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    logicalSessionTimeoutMinutes: 2,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Mongos",
+                    setName:
+                },
+
+                "b:27017": {
+
+                    type: "Mongos",
+                    setName:
+                }
+            },
+            topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: 1,  # Minimum of the two
+            setName:
+        }
+    },
+    # Now an ismaster response with no logicalSessionTimeoutMinutes
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    logicalSessionTimeoutMinutes: 1,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Mongos",
+                    setName:
+                },
+
+                "b:27017": {
+
+                    type: "Mongos",
+                    setName:
+                }
+            },
+            topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,  # Sessions not supported now
+            setName:
+        }
+    }
+]

--- a/t/data/SDAM/sharded/mongos_disconnect.json
+++ b/t/data/SDAM/sharded/mongos_disconnect.json
@@ -1,88 +1,97 @@
 {
-    "description": "Mongos disconnect", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Sharded"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Sharded"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {}
-                ]
-            ]
-        }, 
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Sharded"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b"
+  "description": "Mongos disconnect",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/sharded/mongos_disconnect.yml
+++ b/t/data/SDAM/sharded/mongos_disconnect.yml
@@ -11,14 +11,18 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["b:27017", {
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -38,8 +42,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     },
@@ -64,8 +68,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     },
@@ -76,7 +80,9 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
         ],
 
@@ -96,8 +102,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/sharded/multiple_mongoses.json
+++ b/t/data/SDAM/sharded/multiple_mongoses.json
@@ -1,40 +1,45 @@
 {
-    "description": "Multiple mongoses", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Sharded"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b"
+  "description": "Multiple mongoses",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/sharded/multiple_mongoses.yml
+++ b/t/data/SDAM/sharded/multiple_mongoses.yml
@@ -11,14 +11,18 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["b:27017", {
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -38,8 +42,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/sharded/non_mongos_removed.json
+++ b/t/data/SDAM/sharded/non_mongos_removed.json
@@ -1,39 +1,44 @@
 {
-    "description": "Non-Mongos server in sharded cluster", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Sharded"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ], 
-                [
-                    "b:27017", 
-                    {
-                        "hosts": [
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b"
+  "description": "Non-Mongos server in sharded cluster",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/sharded/non_mongos_removed.yml
+++ b/t/data/SDAM/sharded/non_mongos_removed.yml
@@ -11,7 +11,9 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["b:27017", {
@@ -19,7 +21,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -33,8 +37,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/sharded/normalize_uri_case.json
+++ b/t/data/SDAM/sharded/normalize_uri_case.json
@@ -1,23 +1,24 @@
 {
-    "description": "Normalize URI case", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }, 
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Unknown"
-            }, 
-            "responses": []
-        }
-    ], 
-    "uri": "mongodb://A,B"
+  "description": "Normalize URI case",
+  "uri": "mongodb://A,B",
+  "phases": [
+    {
+      "responses": [],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "Unknown",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/sharded/normalize_uri_case.yml
+++ b/t/data/SDAM/sharded/normalize_uri_case.yml
@@ -24,8 +24,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Unknown",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/sharded/too_new.json
+++ b/t/data/SDAM/sharded/too_new.json
@@ -1,0 +1,44 @@
+{
+  "description": "Multiple mongoses with large minWireVersion",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 999,
+            "maxWireVersion": 1000
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid"
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/sharded/too_new.yml
+++ b/t/data/SDAM/sharded/too_new.yml
@@ -1,0 +1,36 @@
+description: "Multiple mongoses with large minWireVersion"
+uri: "mongodb://a,b"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
+                }],
+                ["b:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid"
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Mongos",
+                    setName:
+                },
+                "b:27017": {
+                    type: "Mongos",
+                    setName:
+                }
+            },
+            topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: false
+        }
+    }
+]

--- a/t/data/SDAM/sharded/too_old.json
+++ b/t/data/SDAM/sharded/too_old.json
@@ -1,0 +1,44 @@
+{
+  "description": "Multiple mongoses with default maxWireVersion of 0",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 2,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid"
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          },
+          "b:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Sharded",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/sharded/too_old.yml
+++ b/t/data/SDAM/sharded/too_old.yml
@@ -1,0 +1,36 @@
+description: "Multiple mongoses with default maxWireVersion of 0"
+uri: "mongodb://a,b"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    minWireVersion: 2,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid"
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Mongos",
+                    setName:
+                },
+                "b:27017": {
+                    type: "Mongos",
+                    setName:
+                }
+            },
+            topologyType: "Sharded",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: false
+        }
+    }
+]

--- a/t/data/SDAM/single/compatible.json
+++ b/t/data/SDAM/single/compatible.json
@@ -1,0 +1,31 @@
+{
+  "description": "Standalone with large maxWireVersion",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/single/compatible.yml
+++ b/t/data/SDAM/single/compatible.yml
@@ -1,0 +1,26 @@
+description: "Standalone with large maxWireVersion"
+uri: "mongodb://a"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: true
+        }
+    }
+]

--- a/t/data/SDAM/single/direct_connection_external_ip.json
+++ b/t/data/SDAM/single/direct_connection_external_ip.json
@@ -1,31 +1,34 @@
 {
-    "description": "Direct connection to RSPrimary via external IP", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "b:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Direct connection to RSPrimary via external IP",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_external_ip.yml
+++ b/t/data/SDAM/single/direct_connection_external_ip.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["b:27017"],  # Internal IP.
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -26,8 +28,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/direct_connection_mongos.json
+++ b/t/data/SDAM/single/direct_connection_mongos.json
@@ -1,28 +1,31 @@
 {
-    "description": "Connect to mongos", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Mongos"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "msg": "isdbgrid", 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Connect to mongos",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Mongos",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_mongos.yml
+++ b/t/data/SDAM/single/direct_connection_mongos.yml
@@ -11,7 +11,9 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -25,8 +27,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/direct_connection_rsarbiter.json
+++ b/t/data/SDAM/single/direct_connection_rsarbiter.json
@@ -1,32 +1,36 @@
 {
-    "description": "Connect to RSArbiter", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSArbiter"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "arbiterOnly": true, 
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Connect to RSArbiter",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "arbiterOnly": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_rsarbiter.yml
+++ b/t/data/SDAM/single/direct_connection_rsarbiter.yml
@@ -12,8 +12,10 @@ phases: [
                    ok: 1,
                    ismaster: false,
                    arbiterOnly: true,
-                   hosts: ["a:27017"],
-                   setName: "rs"
+                   hosts: ["a:27017", "b:27017"],
+                   setName: "rs",
+                   minWireVersion: 0,
+                   maxWireVersion: 6
                 }]
         ],
 
@@ -27,8 +29,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/direct_connection_rsprimary.json
+++ b/t/data/SDAM/single/direct_connection_rsprimary.json
@@ -1,31 +1,35 @@
 {
-    "description": "Connect to RSPrimary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSPrimary"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": true, 
-                        "ok": 1, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Connect to RSPrimary",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_rsprimary.yml
+++ b/t/data/SDAM/single/direct_connection_rsprimary.yml
@@ -11,8 +11,10 @@ phases: [
 
                    ok: 1,
                    ismaster: true,
-                   hosts: ["a:27017"],
-                   setName: "rs"
+                   hosts: ["a:27017", "b:27017"],
+                   setName: "rs",
+                   minWireVersion: 0,
+                   maxWireVersion: 6
                 }]
         ],
 
@@ -26,8 +28,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/direct_connection_rssecondary.json
+++ b/t/data/SDAM/single/direct_connection_rssecondary.json
@@ -1,32 +1,36 @@
 {
-    "description": "Connect to RSSecondary", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": "rs", 
-                        "type": "RSSecondary"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "hosts": [
-                            "a:27017"
-                        ], 
-                        "ismaster": false, 
-                        "ok": 1, 
-                        "secondary": true, 
-                        "setName": "rs"
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Connect to RSSecondary",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_rssecondary.yml
+++ b/t/data/SDAM/single/direct_connection_rssecondary.yml
@@ -12,8 +12,10 @@ phases: [
                     ok: 1,
                     ismaster: false,
                     secondary: true,
-                    hosts: ["a:27017"],
-                    setName: "rs"
+                    hosts: ["a:27017", "b:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -27,8 +29,8 @@ phases: [
                     setName: "rs"
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/direct_connection_slave.json
+++ b/t/data/SDAM/single/direct_connection_slave.json
@@ -1,27 +1,30 @@
 {
-    "description": "Direct connection to slave", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Standalone"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": false, 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Direct connection to slave",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_slave.yml
+++ b/t/data/SDAM/single/direct_connection_slave.yml
@@ -10,7 +10,9 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: false
+                    ismaster: false,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -24,8 +26,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/direct_connection_standalone.json
+++ b/t/data/SDAM/single/direct_connection_standalone.json
@@ -1,27 +1,30 @@
 {
-    "description": "Connect to standalone", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Standalone"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Connect to standalone",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/direct_connection_standalone.yml
+++ b/t/data/SDAM/single/direct_connection_standalone.yml
@@ -10,7 +10,9 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -24,8 +26,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/ls_timeout_standalone.json
+++ b/t/data/SDAM/single/ls_timeout_standalone.json
@@ -1,0 +1,31 @@
+{
+  "description": "Parse logicalSessionTimeoutMinutes from standalone",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "logicalSessionTimeoutMinutes": 7,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": 7,
+        "setName": null
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/single/ls_timeout_standalone.yml
+++ b/t/data/SDAM/single/ls_timeout_standalone.yml
@@ -1,0 +1,35 @@
+description: "Parse logicalSessionTimeoutMinutes from standalone"
+
+uri: "mongodb://a"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    logicalSessionTimeoutMinutes: 7,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: 7,
+            setName:
+        }
+    }
+]

--- a/t/data/SDAM/single/not_ok_response.json
+++ b/t/data/SDAM/single/not_ok_response.json
@@ -1,34 +1,39 @@
 {
-    "description": "Handle a not-ok ismaster response", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "ok": 1
-                    }
-                ], 
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "ok": 0
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Handle a not-ok ismaster response",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "a:27017",
+          {
+            "ok": 0,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/not_ok_response.yml
+++ b/t/data/SDAM/single/not_ok_response.yml
@@ -10,13 +10,17 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["a:27017", {
 
                     ok: 0,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -30,8 +34,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/standalone_removed.json
+++ b/t/data/SDAM/single/standalone_removed.json
@@ -1,27 +1,30 @@
 {
-    "description": "Standalone removed from multi-server topology", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "b:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Unknown"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {
-                        "ismaster": true, 
-                        "ok": 1
-                    }
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a,b"
+  "description": "Standalone removed from multi-server topology",
+  "uri": "mongodb://a,b",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "Unknown",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/standalone_removed.yml
+++ b/t/data/SDAM/single/standalone_removed.yml
@@ -10,7 +10,9 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -24,8 +26,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Unknown",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/data/SDAM/single/too_new.json
+++ b/t/data/SDAM/single/too_new.json
@@ -1,0 +1,31 @@
+{
+  "description": "Standalone with large minWireVersion",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 999,
+            "maxWireVersion": 1000
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/single/too_new.yml
+++ b/t/data/SDAM/single/too_new.yml
@@ -1,0 +1,26 @@
+description: "Standalone with large minWireVersion"
+uri: "mongodb://a"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: false
+        }
+    }
+]

--- a/t/data/SDAM/single/too_old.json
+++ b/t/data/SDAM/single/too_old.json
@@ -1,0 +1,29 @@
+{
+  "description": "Standalone with default maxWireVersion of 0",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Standalone",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/single/too_old.yml
+++ b/t/data/SDAM/single/too_old.yml
@@ -1,0 +1,24 @@
+description: "Standalone with default maxWireVersion of 0"
+uri: "mongodb://a"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true
+                }]
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "Standalone",
+                    setName:
+                }
+            },
+            topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
+            setName: ,
+            compatible: false
+        }
+    }
+]

--- a/t/data/SDAM/single/unavailable_seed.json
+++ b/t/data/SDAM/single/unavailable_seed.json
@@ -1,24 +1,25 @@
 {
-    "description": "Unavailable seed", 
-    "phases": [
-        {
-            "outcome": {
-                "servers": {
-                    "a:27017": {
-                        "setName": null, 
-                        "type": "Unknown"
-                    }
-                }, 
-                "setName": null, 
-                "topologyType": "Single"
-            }, 
-            "responses": [
-                [
-                    "a:27017", 
-                    {}
-                ]
-            ]
-        }
-    ], 
-    "uri": "mongodb://a"
+  "description": "Unavailable seed",
+  "uri": "mongodb://a",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {}
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": null
+      }
+    }
+  ]
 }

--- a/t/data/SDAM/single/unavailable_seed.yml
+++ b/t/data/SDAM/single/unavailable_seed.yml
@@ -20,8 +20,8 @@ phases: [
                     setName:
                 }
             },
-
             topologyType: "Single",
+            logicalSessionTimeoutMinutes: null,
             setName:
         }
     }

--- a/t/sdam_spec.t
+++ b/t/sdam_spec.t
@@ -65,7 +65,7 @@ sub run_test {
     $name =~ s/\.json$//;
 
     # TODO: Fix issue with PossiblePrimary and MongoDB::_Topology::_update_rs_without_primary
-    next if $name eq 'rs/primary_hint_from_secondary_with_mismatched_me';
+    return if $name eq 'rs/primary_hint_from_secondary_with_mismatched_me';
 
     subtest "$name" => sub {
 
@@ -125,6 +125,7 @@ sub check_outcome {
     my $expected_set_name = defined $outcome->{'setName'} ? $outcome->{'setName'} : "";
     is($topology->replica_set_name, $expected_set_name, 'correct setName for topology');
     is($topology->type, $outcome->{'topologyType'}, 'correct topology type');
+    is($topology->logical_session_timeout_minutes, $outcome->{'logicalSessionTimeoutMinutes'}, 'correct ls timeout');
 }
 
 done_testing;

--- a/t/sdam_spec.t
+++ b/t/sdam_spec.t
@@ -64,6 +64,9 @@ sub run_test {
 
     $name =~ s/\.json$//;
 
+    # TODO: Fix issue with PossiblePrimary and MongoDB::_Topology::_update_rs_without_primary
+    next if $name eq 'rs/primary_hint_from_secondary_with_mismatched_me';
+
     subtest "$name" => sub {
 
         my $topology = create_mock_topology( $name, $plan->{'uri'} );


### PR DESCRIPTION
Includes a skipped test spec that I am unsure if applies to this driver, with the PossiblePrimary option.