### PR TITLE
Tests and fixes for issues found by PERL-883

### DIFF
--- a/lib/MongoDB/Collection.pm
+++ b/lib/MongoDB/Collection.pm
@@ -1668,7 +1668,10 @@ sub bulk_write {
         }
     }
 
-    return $bulk->execute( undef, { session => $session } );
+    return $bulk->execute(
+        $options->{writeConcern},
+        { session => $session },
+    );
 }
 
 BEGIN {

--- a/lib/MongoDB/QueryResult.pm
+++ b/lib/MongoDB/QueryResult.pm
@@ -138,7 +138,7 @@ has _cursor_num => (
     isa      => Num,
 );
 
-sub _inc_cursor_num { $_[0]{_cursor_num}++ }
+sub _inc_cursor_num { $_[0]{_cursor_num} += $_[1] }
 
 has _docs => (
     is       => 'ro',

--- a/lib/MongoDB/Role/_CommandCursorOp.pm
+++ b/lib/MongoDB/Role/_CommandCursorOp.pm
@@ -50,6 +50,11 @@ sub _build_result_from_cursor {
         $max_time_ms = $self->maxAwaitTimeMS if $self->maxAwaitTimeMS;
     }
 
+    my $limit = 0;
+    if ($self->isa('MongoDB::Op::_Query')) {
+        $limit = $self->limit if $self->limit;
+    }
+
     my $batch = $c->{firstBatch};
     my $qr = MongoDB::QueryResult->_new(
         _client       => $self->client,
@@ -58,7 +63,7 @@ sub _build_result_from_cursor {
         _bson_codec   => $self->bson_codec,
         _batch_size   => scalar @$batch,
         _cursor_at    => 0,
-        _limit        => 0,
+        _limit        => $limit,
         _cursor_id    => $c->{id},
         _cursor_start => 0,
         _cursor_flags => {},

--- a/t/collection.t
+++ b/t/collection.t
@@ -945,6 +945,17 @@ subtest "querying w/ collation" => sub {
     }
 };
 
+subtest "bulk_write writeConcern used" => sub {
+    $coll->drop;
+
+    like exception {
+        $coll->bulk_write(
+            [insert_one => [{ x => 3 }]],
+            { writeConcern => { w => 999 } },
+        );
+    }, qr/WriteConcernError/, 'write concern is taken into account';
+};
+
 my $js_str = 'function() { return this.a > this.b }';
 my $js_obj = MongoDB::Code->new( code => $js_str );
 

--- a/t/collection.t
+++ b/t/collection.t
@@ -946,6 +946,9 @@ subtest "querying w/ collation" => sub {
 };
 
 subtest "bulk_write writeConcern used" => sub {
+    plan skip_all => "Test requires ReplicaSet"
+        unless $server_type eq 'RSPrimary';
+
     $coll->drop;
 
     like exception {

--- a/t/cursor.t
+++ b/t/cursor.t
@@ -305,6 +305,7 @@ $coll->drop;
     $cursor->all;
     $info = $cursor->info;
     is($info->{at}, 1000);
+    is($info->{num}, 1000, 'cursor_num after ->all');
 }
 
 # sort_by

--- a/t/cursor.t
+++ b/t/cursor.t
@@ -89,6 +89,12 @@ my @values;
     is ($values[2]->{foo}, 4);
 }
 
+# limit propagation to result
+{
+    my $c = $coll->query({}, { limit => 3, sort_by => { foo => 1 } });
+    is($c->result->_limit, 3, 'query limit was propagated');
+}
+
 # skip
 {
     @values = $coll->query({}, { limit => 3, skip => 1, sort_by => { foo => 1 } })->all;


### PR DESCRIPTION
Contains tests and fixes for:

* Incorrect increase of the `num` field in cursor info.
* `CommandCursorOp` not passing its `limit` down to the `QueryResult`.
* `bulk_write` not passing along the `writeConcern` options to `BulkWrite`s `execute`.

I'm unsure how correct the test for the `writeConcern` issue is. It uses `{ w => 999 }` to trigger a failure as used in other places in `collection.t`.