### PR TITLE
Updated (rebased): PERL-782 - Test maxTimeMS is an accepted option

### DIFF
--- a/lib/MongoDB/IndexView.pm
+++ b/lib/MongoDB/IndexView.pm
@@ -291,7 +291,10 @@ sub create_many {
         indexes             => $indexes,
         write_concern       => $self->_write_concern,
         monitoring_callback => $self->_client->monitoring_callback,
-        max_time_ms         => $opts->{maxTimeMS},
+        (defined($opts->{maxTimeMS})
+            ? (max_time_ms   => $opts->{maxTimeMS})
+            : ()
+        ),
     );
 
     # succeed or die; we don't care about response document
@@ -339,7 +342,10 @@ sub drop_one {
         write_concern       => $self->_write_concern,
         index_name          => $name,
         monitoring_callback => $self->_client->monitoring_callback,
-        max_time_ms         => $opts->{maxTimeMS},
+        (defined($opts->{maxTimeMS})
+            ? (max_time_ms   => $opts->{maxTimeMS})
+            : ()
+        ),
     );
 
     $self->_client->send_write_op($op)->output;
@@ -375,7 +381,10 @@ sub drop_all {
         write_concern       => $self->_write_concern,
         index_name          => '*',
         monitoring_callback => $self->_client->monitoring_callback,
-        max_time_ms         => $opts->{maxTimeMS},
+        (defined($opts->{maxTimeMS})
+            ? (max_time_ms   => $opts->{maxTimeMS})
+            : ()
+        ),
     );
 
     $self->_client->send_write_op($op)->output;

--- a/lib/MongoDB/IndexView.pm
+++ b/lib/MongoDB/IndexView.pm
@@ -184,8 +184,15 @@ sub create_one {
     MongoDB::UsageError->throw("Argument to create_one must be an ordered document")
       unless is_OrderedDoc($keys);
 
-    my ($name) =
-      $self->create_many( { keys => $keys, ( $opts ? ( options => $opts ) : () ) } );
+    my $global_opts = {};
+    if (exists $opts->{maxTimeMS}) {
+        $global_opts->{maxTimeMS} = delete $opts->{maxTimeMS};
+    }
+
+    my ($name) = $self->create_many(
+        { keys => $keys, ( $opts ? ( options => $opts ) : () ) },
+        $global_opts,
+    );
     return $name;
 }
 
@@ -196,9 +203,19 @@ sub create_one {
         { keys => [ z => 1 ], options => { unique => 1 } }
     );
 
+    @names = $indexes->create_many(
+        { keys => [ x => 1, y => 1 ] },
+        { keys => [ z => 1 ], options => { unique => 1 } }
+        \%global_options,
+    );
+
 This method takes a list of index models (given as hash references)
 and returns a list of index names created.  It will throw an exception
 on error.
+
+If the last value is a hash reference without a C<keys> entry, it will
+be assumed to be a set of global options. See below for a list of
+accepted global options.
 
 Each index module is described by the following fields:
 
@@ -243,12 +260,24 @@ Some of the more commonly used options include:
 * C<name> — a name (string) for the index; one will be generated if this is
   omitted.
 
+Global options specified as the last value can contain the following
+keys:
+
+=for :list
+* C<maxTimeMS> — maximum time in milliseconds before the operation will
+  time out.
+
 =cut
 
 my $create_many_args;
 
 sub create_many {
     my ( $self, @models ) = @_;
+
+    my $opts;
+    if (@models and ref $models[-1] eq 'HASH' and not exists $models[-1]{keys}) {
+        $opts = pop @models;
+    }
 
     MongoDB::UsageError->throw("Argument to create_many must be a list of index models")
       unless is_IndexModelList(\@models);
@@ -262,6 +291,7 @@ sub create_many {
         indexes             => $indexes,
         write_concern       => $self->_write_concern,
         monitoring_callback => $self->_client->monitoring_callback,
+        max_time_ms         => $opts->{maxTimeMS},
     );
 
     # succeed or die; we don't care about response document
@@ -273,6 +303,7 @@ sub create_many {
 =method drop_one
 
     $output = $indexes->drop_one( $name );
+    $output = $indexes->drop_one( $name, \%options );
 
 This method takes the name of an index and drops it.  It returns the output
 of the dropIndexes command (a hash reference) on success or throws a
@@ -280,12 +311,18 @@ exception if the command errors.  However, if the index does not exist, the
 command output will have the C<ok> field as a false value, but no exception
 will e thrown.
 
+Valid options are:
+
+=for :list
+* C<maxTimeMS> — maximum time in milliseconds before the operation will
+  time out.
+
 =cut
 
 my $drop_one_args;
 
 sub drop_one {
-    my ( $self, $name ) = @_;
+    my ( $self, $name, $opts ) = @_;
 
     MongoDB::UsageError->throw("Argument to drop_one must be a string")
       unless is_Str($name);
@@ -302,6 +339,7 @@ sub drop_one {
         write_concern       => $self->_write_concern,
         index_name          => $name,
         monitoring_callback => $self->_client->monitoring_callback,
+        max_time_ms         => $opts->{maxTimeMS},
     );
 
     $self->_client->send_write_op($op)->output;
@@ -310,17 +348,24 @@ sub drop_one {
 =method drop_all
 
     $output = $indexes->drop_all;
+    $output = $indexes->drop_all(\%options);
 
 This method drops all indexes (except the one on the C<_id> field).  It
 returns the output of the dropIndexes command (a hash reference) on success
 or throws a exception if the command fails.
+
+Valid options are:
+
+=for :list
+* C<maxTimeMS> — maximum time in milliseconds before the operation will
+  time out.
 
 =cut
 
 my $drop_all_args;
 
 sub drop_all {
-    my ($self) = @_;
+    my ($self, $opts) = @_;
 
     my $op = MongoDB::Op::_DropIndexes->_new(
         db_name             => $self->_db_name,
@@ -330,6 +375,7 @@ sub drop_all {
         write_concern       => $self->_write_concern,
         index_name          => '*',
         monitoring_callback => $self->_client->monitoring_callback,
+        max_time_ms         => $opts->{maxTimeMS},
     );
 
     $self->_client->send_write_op($op)->output;

--- a/lib/MongoDB/IndexView.pm
+++ b/lib/MongoDB/IndexView.pm
@@ -174,6 +174,12 @@ direction/type.
 See L</create_many> for important information about index specifications
 and options.
 
+The following additional options are recognized:
+
+=for :list
+* C<maxTimeMS> — maximum time in milliseconds before the operation will
+  time out.
+
 =cut
 
 my $create_one_args;

--- a/lib/MongoDB/Op/_CreateIndexes.pm
+++ b/lib/MongoDB/Op/_CreateIndexes.pm
@@ -32,6 +32,7 @@ use Types::Standard qw(
     ArrayRef
     Bool
     HashRef
+    Num
 );
 
 use namespace::clean;
@@ -40,6 +41,11 @@ has indexes => (
     is       => 'ro',
     required => 1,
     isa      => ArrayRef [HashRef],
+);
+
+has max_time_ms => (
+    is => 'ro',
+    isa => Num,
 );
 
 with $_ for qw(
@@ -76,7 +82,11 @@ sub _command_create_indexes {
         query   => [
             createIndexes => $self->coll_name,
             indexes       => $self->indexes,
-            ( $link->accepts_wire_version(5) ? ( @{ $self->write_concern->as_args } ) : () )
+            ( $link->accepts_wire_version(5) ? ( @{ $self->write_concern->as_args } ) : () ),
+            (defined($self->max_time_ms)
+                ? (maxTimeMS => $self->max_time_ms)
+                : ()
+            ),
         ],
         query_flags         => {},
         bson_codec          => $self->bson_codec,

--- a/lib/MongoDB/Op/_DropIndexes.pm
+++ b/lib/MongoDB/Op/_DropIndexes.pm
@@ -30,6 +30,7 @@ use MongoDB::Op::_Command;
 use Safe::Isa;
 use Types::Standard qw(
   Str
+  Num
 );
 
 use namespace::clean;
@@ -38,6 +39,11 @@ has index_name => (
     is       => 'ro',
     required => 1,
     isa      => Str,
+);
+
+has max_time_ms => (
+    is => 'ro',
+    isa => Num,
 );
 
 with $_ for qw(
@@ -55,6 +61,10 @@ sub execute {
             dropIndexes => $self->coll_name,
             index       => $self->index_name,
             ( $link->accepts_wire_version(5) ? ( @{ $self->write_concern->as_args } ) : () ),
+            (defined($self->max_time_ms)
+                ? (maxTimeMS => $self->max_time_ms)
+                : ()
+            ),
         ],
         query_flags         => {},
         bson_codec          => $self->bson_codec,

--- a/t/indexview.t
+++ b/t/indexview.t
@@ -42,11 +42,6 @@ my $valid_collation           = { locale => "en_US", strength => 2 };
 my $valid_collation_alternate = { locale => "fr_CA" };
 my $invalid_collation         = { locale => "en_US", blah => 5 };
 
-my $param = eval {
-    $conn->get_database('admin')
-      ->run_command( [ getParameter => 1, enableTestCommands => 1 ] );
-};
-
 my ($iv);
 
 # XXX work around SERVER-18062; create collection to initialize DB for
@@ -112,79 +107,6 @@ subtest "create_many" => sub {
             "create_many w/ collation returns error if unsupported"
         );
     }
-};
-
-subtest "create_many w/ maxTimeMS" => sub {
-    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
-      unless $ENV{FAILPOINT_TESTING};
-
-    plan skip_all => "maxTimeMS not available before 3.6"
-      unless $server_version >= v3.6.0;
-
-    plan skip_all => "enableTestCommands is off"
-      unless $param && $param->{enableTestCommands};
-
-    plan skip_all => "fail points not supported via mongos"
-      if $server_type eq 'Mongos';
-
-    plan skip_all => "not safe to run fail points before Test::Harness 3.31"
-      if version->parse($ENV{HARNESS_VERSION}) < version->parse(3.31);
-
-    $coll->drop;
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'alwaysOn',
-            ]);
-        },
-        undef,
-        'max time failpoint on',
-    );
-
-    like(
-        exception {
-            $iv->create_many(
-                { keys => [ x => 1 ] }, { keys => [ y => -1 ] },
-                { maxTimeMS => 10 },
-            );
-        },
-        qr/exceeded time limit/,
-        'timeout for index creation',
-    );
-
-    is(
-        exception {
-            $iv->create_many(
-                { keys => [ x => 1 ] }, { keys => [ y => -1 ] },
-            );
-        },
-        undef,
-        'no timeout without max time',
-    );
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'off',
-            ]);
-        },
-        undef,
-        'max time failpoint off',
-    );
-
-    is(
-        exception {
-            $iv->create_many(
-                { keys => [ x => 1 ] }, { keys => [ y => -1 ] },
-                { maxTimeMS => 5000 },
-            );
-        },
-        undef,
-        'no timeout for index creation',
-    );
 };
 
 subtest "list indexes" => sub {
@@ -267,71 +189,6 @@ subtest "create_one" => sub {
     }
 };
 
-subtest "create_one w/ maxTimeMS" => sub {
-    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
-      unless $ENV{FAILPOINT_TESTING};
-
-    plan skip_all => "maxTimeMS not available before 3.6"
-      unless $server_version >= v3.6.0;
-
-    plan skip_all => "enableTestCommands is off"
-      unless $param && $param->{enableTestCommands};
-
-    plan skip_all => "fail points not supported via mongos"
-      if $server_type eq 'Mongos';
-
-    plan skip_all => "not safe to run fail points before Test::Harness 3.31"
-      if version->parse($ENV{HARNESS_VERSION}) < version->parse(3.31);
-
-    $coll->drop;
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'alwaysOn',
-            ]);
-        },
-        undef,
-        'max time failpoint on',
-    );
-
-    is(
-        exception {
-            $iv->create_one([ x => 1 ]);
-        },
-        undef,
-        'no timeout without max time',
-    );
-
-    like(
-        exception {
-            $iv->create_one([ x => 1 ], { maxTimeMS => 10 });
-        },
-        qr/exceeded time limit/,
-        'timeout for index creation',
-    );
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'off',
-            ]);
-        },
-        undef,
-        'max time failpoint off',
-    );
-
-    is(
-        exception {
-            $iv->create_one([ x => 1 ], { maxTimeMS => 5000 });
-        },
-        undef,
-        'no timeout for index creation',
-    );
-};
-
 subtest "drop_one" => sub {
     $coll->drop;
     ok( my $name = $iv->create_one( [ x => 1 ] ), "created index on x" );
@@ -368,74 +225,6 @@ subtest "drop_one" => sub {
     );
 };
 
-subtest "drop_one w/ maxTimeMS" => sub {
-    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
-      unless $ENV{FAILPOINT_TESTING};
-
-    plan skip_all => "maxTimeMS not available before 3.6"
-      unless $server_version >= v3.6.0;
-
-    plan skip_all => "enableTestCommands is off"
-      unless $param && $param->{enableTestCommands};
-
-    plan skip_all => "fail points not supported via mongos"
-      if $server_type eq 'Mongos';
-
-    plan skip_all => "not safe to run fail points before Test::Harness 3.31"
-      if version->parse($ENV{HARNESS_VERSION}) < version->parse(3.31);
-
-    $coll->drop;
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'alwaysOn',
-            ]);
-        },
-        undef,
-        'max time failpoint on',
-    );
-
-    is(
-        exception {
-            my $name = $iv->create_one([ x => 1 ]);
-            $iv->drop_one($name);
-        },
-        undef,
-        'no timeout without max time',
-    );
-
-    like(
-        exception {
-            my $name = $iv->create_one([ x => 1 ]);
-            $iv->drop_one($name, { maxTimeMS => 10 });
-        },
-        qr/exceeded time limit/,
-        'timeout for index drop',
-    );
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'off',
-            ]);
-        },
-        undef,
-        'max time failpoint off',
-    );
-
-    is(
-        exception {
-            my $name = $iv->create_one([ x => 1 ]);
-            $iv->drop_one($name, { maxTimeMS => 5000 });
-        },
-        undef,
-        'no timeout for index drop',
-    );
-};
-
 subtest "drop_all" => sub {
     $coll->drop;
     $iv->create_many( map { { keys => $_ } }[ x => 1 ], [ y => 1 ], [ z => 1 ] );
@@ -450,74 +239,6 @@ subtest "drop_all" => sub {
     is_deeply( [ sort map $_->{name}, $iv->list->all ],
         [qw/_id_/], "dropped all but _id index" );
 
-};
-
-subtest "drop_all w/ maxTimeMS" => sub {
-    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
-      unless $ENV{FAILPOINT_TESTING};
-
-    plan skip_all => "maxTimeMS not available before 3.6"
-      unless $server_version >= v3.6.0;
-
-    plan skip_all => "enableTestCommands is off"
-      unless $param && $param->{enableTestCommands};
-
-    plan skip_all => "fail points not supported via mongos"
-      if $server_type eq 'Mongos';
-
-    plan skip_all => "not safe to run fail points before Test::Harness 3.31"
-      if version->parse($ENV{HARNESS_VERSION}) < version->parse(3.31);
-
-    $coll->drop;
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'alwaysOn',
-            ]);
-        },
-        undef,
-        'max time failpoint on',
-    );
-
-    is(
-        exception {
-            $iv->create_many( map { { keys => $_ } }[ x => 1 ], [ y => 1 ], [ z => 1 ] );
-            $iv->drop_all();
-        },
-        undef,
-        'no timeout without max time',
-    );
-
-    like(
-        exception {
-            $iv->create_many( map { { keys => $_ } }[ x => 1 ], [ y => 1 ], [ z => 1 ] );
-            $iv->drop_all({ maxTimeMS => 10 });
-        },
-        qr/exceeded time limit/,
-        'timeout for index drop',
-    );
-
-    is(
-        exception {
-            $admin->run_command([
-                configureFailPoint => 'maxTimeAlwaysTimeOut',
-                mode => 'off',
-            ]);
-        },
-        undef,
-        'max time failpoint off',
-    );
-
-    is(
-        exception {
-            $iv->create_many( map { { keys => $_ } }[ x => 1 ], [ y => 1 ], [ z => 1 ] );
-            $iv->drop_all({ maxTimeMS => 5000 });
-        },
-        undef,
-        'no timeout for index drop',
-    );
 };
 
 subtest 'handling duplicates' => sub {

--- a/t/indexview.t
+++ b/t/indexview.t
@@ -115,6 +115,9 @@ subtest "create_many" => sub {
 };
 
 subtest "create_many w/ maxTimeMS" => sub {
+    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
+      unless $ENV{FAILPOINT_TESTING};
+
     plan skip_all => "maxTimeMS not available before 3.6"
       unless $server_version >= v3.6.0;
 
@@ -265,6 +268,9 @@ subtest "create_one" => sub {
 };
 
 subtest "create_one w/ maxTimeMS" => sub {
+    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
+      unless $ENV{FAILPOINT_TESTING};
+
     plan skip_all => "maxTimeMS not available before 3.6"
       unless $server_version >= v3.6.0;
 
@@ -363,6 +369,9 @@ subtest "drop_one" => sub {
 };
 
 subtest "drop_one w/ maxTimeMS" => sub {
+    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
+      unless $ENV{FAILPOINT_TESTING};
+
     plan skip_all => "maxTimeMS not available before 3.6"
       unless $server_version >= v3.6.0;
 
@@ -444,6 +453,9 @@ subtest "drop_all" => sub {
 };
 
 subtest "drop_all w/ maxTimeMS" => sub {
+    plan skip_all => "\$ENV{FAILPOINT_TESTING} is false"
+      unless $ENV{FAILPOINT_TESTING};
+
     plan skip_all => "maxTimeMS not available before 3.6"
       unless $server_version >= v3.6.0;
 


### PR DESCRIPTION
Add maxTimeMS option to IndexView's create_one, create_many, drop_one and drop_all.

API Changes:
* Last value of create_many is now an optional hash reference with global options.
* create_one received an additional maxTimeMS option.
* drop_one and drop_all now accept an options hash reference with maxTimeMS.

Rebased version of [PR 154](https://github.com/mongodb/mongo-perl-driver/pull/154)