### PR TITLE
PERL-890 command monitoring updates

### DIFF
--- a/t/data/command-monitoring/README.rst
+++ b/t/data/command-monitoring/README.rst
@@ -14,6 +14,12 @@ Testing
 
 Tests are provided in YML and JSON format to assert proper upconversion of commands.
 
+Database and Collection Names
+-----------------------------
+
+The collection under test is specified in each test file with the fields
+``database_name`` and ``collection_name``.
+
 Data
 ----
 

--- a/t/data/command-monitoring/bulkWrite.json
+++ b/t/data/command-monitoring/bulkWrite.json
@@ -23,7 +23,8 @@
         "arguments": {
           "requests": [
             {
-              "insertOne": {
+              "name": "insertOne",
+              "arguments": {
                 "document": {
                   "_id": 4,
                   "x": 44
@@ -31,7 +32,8 @@
               }
             },
             {
-              "updateOne": {
+              "name": "updateOne",
+              "arguments": {
                 "filter": {
                   "_id": 3
                 },

--- a/t/data/command-monitoring/bulkWrite.yml
+++ b/t/data/command-monitoring/bulkWrite.yml
@@ -13,9 +13,11 @@ tests:
       name: "bulkWrite"
       arguments:
         requests:
-          - insertOne: 
+          - name: "insertOne"
+            arguments:
               document: { _id: 4, x: 44 }
-          - updateOne:
+          - name: "updateOne"
+            arguments:
               filter: { _id: 3 }
               update: { $set: { x: 333 } }
     expectations:

--- a/t/data/command-monitoring/insertMany.json
+++ b/t/data/command-monitoring/insertMany.json
@@ -108,7 +108,9 @@
               "x": 22
             }
           ],
-          "ordered": false
+          "options": {
+            "ordered": false
+          }
         }
       },
       "expectations": [

--- a/t/data/command-monitoring/insertMany.yml
+++ b/t/data/command-monitoring/insertMany.yml
@@ -58,7 +58,7 @@ tests:
       arguments:
         documents:
           - { _id: 2, x: 22 }
-        ordered: false
+        options: { ordered: false }
     expectations:
       -
         command_started_event:

--- a/t/data/command-monitoring/unacknowledgedBulkWrite.json
+++ b/t/data/command-monitoring/unacknowledgedBulkWrite.json
@@ -13,10 +13,16 @@
       "comment": "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply",
       "operation": {
         "name": "bulkWrite",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        },
         "arguments": {
           "requests": [
             {
-              "insertOne": {
+              "name": "insertOne",
+              "arguments": {
                 "document": {
                   "_id": "unorderedBulkWriteInsertW0",
                   "x": 44
@@ -24,9 +30,8 @@
               }
             }
           ],
-          "ordered": false,
-          "writeConcern": {
-            "w": 0
+          "options": {
+            "ordered": false
           }
         }
       },

--- a/t/data/command-monitoring/unacknowledgedBulkWrite.yml
+++ b/t/data/command-monitoring/unacknowledgedBulkWrite.yml
@@ -10,12 +10,14 @@ tests:
     comment: "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply"
     operation:
       name: "bulkWrite"
+      collectionOptions:
+        writeConcern: { w: 0 }
       arguments:
         requests:
-          - insertOne: 
+          - name: "insertOne"
+            arguments:
               document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
-        ordered: false
-        writeConcern: { w: 0 }
+        options: { ordered: false }
     expectations:
       -
         command_started_event:

--- a/t/monitoring_spec.t
+++ b/t/monitoring_spec.t
@@ -417,20 +417,7 @@ sub check_command_field {
         my $exp_value = prepare_data_spec($exp_command->{$exp_key});
         my $label = "command field '$exp_key'";
 
-        if (
-            (grep { $exp_key eq $_ } qw( comment maxTimeMS writeConcern ))
-            or
-            ($event->{commandName} eq 'getMore' and $exp_key eq 'batchSize')
-        ) {
-            TODO: {
-                local $TODO =
-                    "Command field '$exp_key' requires other fixes";
-                cmp_deeply $event_value, $exp_value, $label;
-            }
-        }
-        else {
-            cmp_deeply $event_value, $exp_value, $label;
-        }
+        cmp_deeply $event_value, $exp_value, $label;
     }
 }
 


### PR DESCRIPTION
Contains:

* Specification test data updates
* Adaption of new `bulk_write` test data format.
* `collectionOptions` integration
* Passing `options` field as option argument to methods.

TODO tests are now passing for me locally.