### PR TITLE
PERL-806 Check compatibility for SDAM tests

### DIFF
--- a/lib/MongoDB/_Topology.pm
+++ b/lib/MongoDB/_Topology.pm
@@ -597,9 +597,10 @@ sub _check_wire_versions {
         my ( $server_min_wire_version, $server_max_wire_version ) =
           @{ $server->is_master }{qw/minWireVersion maxWireVersion/};
 
-        # set to -1 as could be undefined, or 0.
-        $server_max_wire_version = -1 unless defined $server_max_wire_version;
-        $server_min_wire_version = -1 unless defined $server_min_wire_version;
+        # set to 0 as could be undefined. 0 is the equivalent to missing, and
+        # also kept as 0 for legacy compatibility.
+        $server_max_wire_version = 0 unless defined $server_max_wire_version;
+        $server_min_wire_version = 0 unless defined $server_min_wire_version;
 
         if ( $server_min_wire_version > $self->max_wire_version
           || $server_max_wire_version < $self->min_wire_version ) {

--- a/lib/MongoDB/_Topology.pm
+++ b/lib/MongoDB/_Topology.pm
@@ -597,8 +597,9 @@ sub _check_wire_versions {
         my ( $server_min_wire_version, $server_max_wire_version ) =
           @{ $server->is_master }{qw/minWireVersion maxWireVersion/};
 
-        $server_max_wire_version = 0 unless defined $server_max_wire_version;
-        $server_min_wire_version = 0 unless defined $server_min_wire_version;
+        # set to -1 as could be undefined, or 0.
+        $server_max_wire_version = -1 unless defined $server_max_wire_version;
+        $server_min_wire_version = -1 unless defined $server_min_wire_version;
 
         if ( $server_min_wire_version > $self->max_wire_version
           || $server_max_wire_version < $self->min_wire_version ) {
@@ -1200,8 +1201,9 @@ sub _update_rs_with_primary_from_member {
         $self->_remove_server($new_server);
     }
 
-    # require 'me' that matches expected address
-    if ( $new_server->me && $new_server->me ne $new_server->address ) {
+    # require 'me' that matches expected address.
+    # check is case insensitive
+    if ( $new_server->me && lc $new_server->me ne $new_server->address ) {
         $self->_remove_server($new_server);
         $self->_check_for_primary;
         return;

--- a/t/data/SDAM/README.rst
+++ b/t/data/SDAM/README.rst
@@ -9,14 +9,8 @@ Server Discovery And Monitoring Spec.
 Version
 -------
 
-Files in the "specifications" repository have no version scheme.
-They are not tied to a MongoDB server version,
-and it is our intention that each specification moves from "draft" to "final"
-with no further versions; it is superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target.
-As test files evolve they will be occasionally tagged like
-"server-discovery-tests-2014-09-10", until the spec is final.
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version.
 
 Format
 ------

--- a/t/data/SDAM/rs/normalize_case_me.json
+++ b/t/data/SDAM/rs/normalize_case_me.json
@@ -1,0 +1,93 @@
+{
+  "description": "Replica set mixed case normalization",
+  "uri": "mongodb://A/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "me": "A:27017",
+            "hosts": [
+              "A:27017"
+            ],
+            "passives": [
+              "B:27017"
+            ],
+            "arbiters": [
+              "C:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "me": "B:27017",
+            "hosts": [
+              "A:27017"
+            ],
+            "passives": [
+              "B:27017"
+            ],
+            "arbiters": [
+              "C:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/t/data/SDAM/rs/normalize_case_me.yml
+++ b/t/data/SDAM/rs/normalize_case_me.yml
@@ -1,0 +1,100 @@
+description: "Replica set mixed case normalization"
+
+uri: "mongodb://A/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    me: "A:27017",
+                    hosts: ["A:27017"],
+                    passives: ["B:27017"],
+                    arbiters: ["C:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    me: "B:27017",
+                    hosts: ["A:27017"],
+                    passives: ["B:27017"],
+                    arbiters: ["C:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]


### PR DESCRIPTION
Contains the fixes for SDAM spec tests as well. Issues where:

* Case insensitive matching of `is_master.me` value to address
* Servers providing no min/max wire version where incorrectly coming back as compatible (according to `too_old.yml` tests)
* Not checking compatibility value from yml tests

One thing that isnt in this one, is there is a `monitoring` folder for the SDAM spec tests repo - are these implemented elsewhere or do these need doing?