### PR TITLE
PERL-780 added documentation for TCP keepalive

### DIFF
--- a/lib/MongoDB/MongoClient.pm
+++ b/lib/MongoDB/MongoClient.pm
@@ -745,6 +745,10 @@ If set to a negative value, socket operations will block indefinitely
 until the server replies or until the operating system TCP/IP stack
 gives up.
 
+The driver automatically sets the TCP keepalive option when initializing the
+socket. For keepalive related issues, check the MongoDB documentation for
+L<Does TCP keepalive time affect MongoDB Deployments?|https://docs.mongodb.com/v3.2/faq/diagnostics/#does-tcp-keepalive-time-affect-mongodb-deployments>.
+
 A zero value polls the socket for available data and is thus likely to fail
 except when talking to a local process (and perhaps even then).
 


### PR DESCRIPTION
Added documentatin to `socket_timeout_ms` as the closest related option, with link to the FAQ for TCP keepalive issues. The actual implementation is in `MongoDB::_Link`, however as that is a private class no public documentation exists in there. If this would be better suited elsewhere, or at least linked from other places in the module, then that can be added.