### PR TITLE
PERL-1129 Apply TLS options from URI

### DIFF
--- a/devel/lib/MongoDBTest/Role/Server.pm
+++ b/devel/lib/MongoDBTest/Role/Server.pm
@@ -512,7 +512,7 @@ sub _command_args {
     push @args, split ' ', $self->config->{args} if exists $self->config->{args};
     push @args, split ' ', $self->command_args;
     push @args, '--port', $self->port, '--logpath', $self->logfile, '--logappend';
-    if ($self->did_auth_setup) {
+    if ($self->did_auth_setup || $self->did_ssl_auth_setup) {
         push @args, '--auth';
     }
     if (my $ssl = $self->ssl_config) {
@@ -525,7 +525,12 @@ sub _command_args {
         if ( $ssl->{disabled_protocols} ) {
             push @args, '--sslDisabledProtocols', join(",", @{$ssl->{disabled_protocols}});
         }
-        if (! $self->did_ssl_auth_setup) {
+        if ( $self->did_ssl_auth_setup) {
+            if ( $ssl->{client_cert_not_required} ) {
+                push @args, '--sslAllowConnectionsWithoutCertificates';
+            }
+        }
+        else {
             push @args,
                 $self->server_version >= v3.0.0
                 ? '--sslAllowConnectionsWithoutCertificates'

--- a/lib/MongoDB/_URI.pm
+++ b/lib/MongoDB/_URI.pm
@@ -114,7 +114,6 @@ sub _build_valid_options {
             heartbeatFrequencyMS
             journal
             localThresholdMS
-            maxIdleTimeMS
             maxStalenessSeconds
             maxTimeMS
             readConcernLevel
@@ -188,7 +187,6 @@ sub _build_extra_options_validation {
       localthresholdms => '_PositiveInt',
       serverselectiontimeoutms => '_PositiveInt',
       sockettimeoutms => '_PositiveInt',
-      maxidletimems => '_PositiveInt',
       w => sub {
           my $v = shift;
           if (looks_like_number($v)) {

--- a/t/unit/uri_spec.t
+++ b/t/unit/uri_spec.t
@@ -28,6 +28,7 @@ my $dir      = path('t/data/uri/');
 my $iterator = $dir->iterator( { recurse => 1 } );
 while ( my $path = $iterator->() ) {
     next unless -f $path && $path =~ /\.json$/;
+    next if $path =~ /connection-pool-options/;
     my $plan = decode_json( $path->slurp_utf8 );
     subtest $path->basename => sub {
         foreach my $test ( @{ $plan->{'tests'} } ) {
@@ -62,6 +63,12 @@ sub run_options_test {
     }
 
     # Valid case
+
+    # maxIdleTimeMS is only for drivers with a connection pool.
+    if ($test->{uri} =~ /maxIdleTimeMS/) {
+        $test->{uri} =~ s{maxIdleTimeMS=\d+\&}{};
+        delete $test->{options}{maxIdleTimeMS};
+    }
 
     my @warnings = ();
     local $SIG{__WARN__} = sub { push @warnings, $_[0] };

--- a/t/unit/uri_srv.t
+++ b/t/unit/uri_srv.t
@@ -62,7 +62,7 @@ subtest "boolean params unchanged" => sub {
         "hostids correct";
 
     is_deeply $uri->options,
-        { ssl => 1, retrywrites => 1, retryreads => 0 },
+        { ssl => 1, tls => 1, retrywrites => 1, retryreads => 0 },
         "options correct";
 
     subtest "force call srv parsing" => sub {


### PR DESCRIPTION
Prior to this commit, TLS options were parsed, but not applied to the
client.  This commit sets IO::Socket::SSL options based on tls options
on the URI.